### PR TITLE
Prepend JSONP response with empty comment to avoid CSRF

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -197,7 +197,7 @@ public final class Application extends Controller {
 	private static Status withCallback(final String[] callback,
 			final JsonNode shortJson) {
 		return callback != null ? ok(String
-				.format("%s(%s)", callback[0], shortJson)) : ok(shortJson);
+				.format("/**/%s(%s)", callback[0], shortJson)) : ok(shortJson);
 	}
 
 	private static JsonNode fullJsonResponse(final List<Document> documents,


### PR DESCRIPTION
Details: 
http://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/

Deployed to staging: 
http://test.lobid.org/resource?name=Faust&format=full&callback=test
