### PR TITLE
Support multiple comma separated values with OR for `type=` param

### DIFF
--- a/app/models/Search.java
+++ b/app/models/Search.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.FilterBuilders;
-import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -236,9 +235,9 @@ public class Search {
 			queryBuilder = boolQuery().must(queryBuilder).must(setQuery);
 		}
 		if (!type.isEmpty()) {
-			final QueryBuilder typeQuery =
-					matchQuery("@graph.@type", type).operator(
-							MatchQueryBuilder.Operator.AND);
+			BoolQueryBuilder typeQuery = boolQuery();
+			for (String t : type.split(","))
+				typeQuery = typeQuery.should(matchQuery("@graph.@type", t));
 			queryBuilder = boolQuery().must(queryBuilder).must(typeQuery);
 		}
 		if (queryBuilder == null)

--- a/app/views/api.scala.html
+++ b/app/views/api.scala.html
@@ -62,7 +62,7 @@
 		<p>All endpoints use GET and support queries using the <code>id</code>, <code>name</code>, <code>q</code> (query all fields, supports <a href="http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax">elasticsearch query string syntax</a>), and <code>format</code> parameters.
     Result formats <code>short</code>, <code>ids</code>, and <code>full</code> return JSON; use <code>format=negotiate</code> (or none), and set an accept header for different RDF formats, see details below.
     The <code>short</code> result format supports an optional modifier to specify the field to use for collecting the values. The syntax is <code>short.field</code>, see this <a href="/resource?id=HT002189125&format=short.fulltextOnline">sample request</a>. All queries can be filtered by type using the <code>type</code> parameter, see this 
-    <a href="/subject?name=Heinsberg&type=http://d-nb.info/standards/elementset/gnd%23BuildingOrMemorial">sample request</a>. Note that you have to encode the <code>#</code> as <code>%23</code> (the hash is interpreted as a local anchor by the browser, and not sent to the server).</p>
+    <a href="/subject?name=Heinsberg&type=http://d-nb.info/standards/elementset/gnd%23BuildingOrMemorial">sample request</a> (pass multiple comma-separated types for OR query). Note that you have to encode the <code>#</code> as <code>%23</code> (the hash is interpreted as a local anchor by the browser, and not sent to the server).</p>
 		<table class="table table-striped">
 		<tr>
 			<th style="width: 10%">Parameters &rarr; <br/>&darr; Endpoint</th>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,7 +1,7 @@
 # This is the main configuration file for the application.
 # ~~~~~
 
-application.version="1.13.0"
+application.version="1.14.0"
 application.url="http://api.lobid.org" # staging: "http://staging.api.lobid.org"
 application.index.suffix="" # staging: "-staging"
 application.es.server="193.30.112.170" # staging: "193.30.112.84"

--- a/test/tests/SearchEntitiesNarrowByTypeTests.java
+++ b/test/tests/SearchEntitiesNarrowByTypeTests.java
@@ -28,6 +28,9 @@ public class SearchEntitiesNarrowByTypeTests extends SearchTestsHarness {
 	@Test public void differentiatedPersons() { search("person?q=*&t=http://d-nb.info/standards/elementset/gnd#DifferentiatedPerson", 9); }
 	@Test public void undifferentiatedPersons() { search("person?q=*&t=http://d-nb.info/standards/elementset/gnd#UndifferentiatedPerson", 4); }
 	@Test public void subjects() { search("subject?q=*", 17); }
+	@Test public void booksOrJournals() { search("resource?q=*&t=http://purl.org/ontology/bibo/Book,http://purl.org/ontology/bibo/Journal", 20); }
+	@Test public void differentiatedOrUndifferentiatedPersons() { search(
+			"person?q=*&t=http://d-nb.info/standards/elementset/gnd#DifferentiatedPerson,http://d-nb.info/standards/elementset/gnd#UndifferentiatedPerson", 13); }
 	//@formatter:on
 
 	private static void search(final String q, final int hits) {


### PR DESCRIPTION
See https://github.com/lobid/lodmill/issues/508

Deployed to staging, see:
http://test.lobid.org/subject?name=Heinsberg&type=http://d-nb.info/standards/elementset/gnd%23BuildingOrMemorial,http://d-nb.info/standards/elementset/gnd%23PlaceOrGeographicName&format=full
