### PR TITLE
Support ranges in resource queries like `issued=1993-2008`

### DIFF
--- a/app/models/queries/LobidResources.java
+++ b/app/models/queries/LobidResources.java
@@ -182,7 +182,10 @@ public class LobidResources {
 
 		@Override
 		public QueryBuilder build(String queryString) {
-			return multiMatchQuery(queryString, fields().toArray(new String[] {}));
+			final String[] elems = queryString.split("-");
+			return elems.length == 2 ? //
+			QueryBuilders.rangeQuery(fields().get(0)).gte(elems[0]).lte(elems[1])
+					: multiMatchQuery(queryString, fields().toArray(new String[] {}));
 		}
 	}
 

--- a/test/tests/SearchResourceCombineFieldsTests.java
+++ b/test/tests/SearchResourceCombineFieldsTests.java
@@ -27,6 +27,7 @@ public class SearchResourceCombineFieldsTests extends SearchTestsHarness {
 	@Test public void searchAuthorAndId(){search("resource?author=hu&id=9781402083891", 1);}
 	@Test public void searchAuthorAndSubject(){search("resource?author=hu&subject=4026453-1", 1);}
 	@Test public void searchNameAndIssued(){search("resource?name=der&issued=2008", 1);}
+	@Test public void searchNameAndIssuedRange(){search("resource?name=der&issued=1993-2008", 3);}
 	@Test public void searchNameAndPublisher(){search("resource?name=der&publisher=Springer", 1);}
 	/*@formatter:on@*/
 


### PR DESCRIPTION
See #45 

Deployed to staging, see: http://test.lobid.org/resource?name=Typee&issued=1970-1980
