### PR TITLE
Support `medium=` query parameter for lobid-resources

### DIFF
--- a/app/controllers/Api.java
+++ b/app/controllers/Api.java
@@ -38,6 +38,7 @@ public final class Api extends Controller {
 	 * @param subject The resource subject
 	 * @param publisher The resource publisher
 	 * @param issued The year the resource was issued
+	 * @param medium The publication medium
 	 * @param set The resource set
 	 * @param format The result format
 	 * @param from The start index of the result set
@@ -53,9 +54,9 @@ public final class Api extends Controller {
 			final String q,
 			final String name, // NOPMD
 			final String author, final String subject, final String publisher,
-			final String issued, final String set, final String format,
-			final int from, final int size, final String owner, final String type,
-			final String sort, final boolean addQueryInfo) {
+			final String issued, final String medium, final String set,
+			final String format, final int from, final int size, final String owner,
+			final String type, final String sort, final boolean addQueryInfo) {
 		Logger
 				.debug(String
 						.format(
@@ -71,6 +72,7 @@ public final class Api extends Controller {
 						.put(Parameter.SUBJECT, subject)
 						.put(Parameter.PUBLISHER, publisher)
 						.put(Parameter.ISSUED, issued)
+						.put(Parameter.MEDIUM, medium)
 						.put(Parameter.SET, set).build());/*@formatter:on*/
 		return Application.search(index, parameters, format, from, size, owner,
 				set, type, sort, addQueryInfo);
@@ -201,8 +203,8 @@ public final class Api extends Controller {
 		}
 		Promise<List<Result>> results =
 				Promise.sequence(
-						resource(id, q, name, "", "", "", "", "", format, from, size, "",
-								"", "", true),
+						resource(id, q, name, "", "", "", "", "", "", format, from, size,
+								"", "", "", true),
 						organisation(id, q, name, format, from, size, "", true),
 						person(id, q, name, format, from, size, "", true),
 						subject(id, q, name, format, from, size, ""));

--- a/app/controllers/Facets.java
+++ b/app/controllers/Facets.java
@@ -57,6 +57,7 @@ public final class Facets extends Controller {
 	 * @param subject The resource subject
 	 * @param publisher The resource publisher
 	 * @param issued The resources's issued date
+	 * @param medium The publication medium
 	 * @param set The resource set
 	 * @param owner The ID of an owner holding items of the requested resources
 	 * @param size The number of results to receive
@@ -66,10 +67,11 @@ public final class Facets extends Controller {
 	 */
 	public static Promise<Result> resource(String id, String q, String author,
 			String name, String subject, String publisher, String issued,
-			String owner, String set, int size, String t, String field) {
+			String medium, String owner, String set, int size, String t, String field) {
 		String key =
-				String.format("facets.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s", id, q, author,
-						name, subject, publisher, issued, owner, set, size, field);
+				String.format("facets.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s", id, q,
+						author, name, subject, publisher, issued, medium, owner, set, size,
+						field);
 		Logger.info(key);
 		Result cachedResult = (Result) Cache.get(key);
 		if (cachedResult != null) {
@@ -77,7 +79,7 @@ public final class Facets extends Controller {
 		}
 		Promise<Result> result =
 				createJsonResponse(getElasticsearchFacets(id, q, author, name, subject,
-						publisher, issued, owner, set, field, size, t));
+						publisher, issued, medium, owner, set, field, size, t));
 		result.onRedeem(r -> Cache.set(key, r, ONE_DAY));
 		return result;
 	}
@@ -105,14 +107,14 @@ public final class Facets extends Controller {
 
 	private static Promise<org.elasticsearch.search.facet.Facets> getElasticsearchFacets(
 			String id, String q, String author, String name, String subject,
-			String publisher, String issued, String owner, String set, String field,
-			int size, String t) {
+			String publisher, String issued, String medium, String owner, String set,
+			String field, int size, String t) {
 		Promise<org.elasticsearch.search.facet.Facets> promise =
 				Promise.promise(
 						() -> {
 							QueryBuilder query =
 									createQuery(id, q, author, name, subject, publisher, issued,
-											set, owner, t);
+											medium, set, owner, t);
 							SearchRequestBuilder req =
 									createRequest(owner, field, query, size);
 							long start = System.currentTimeMillis();
@@ -129,8 +131,8 @@ public final class Facets extends Controller {
 	}
 
 	private static QueryBuilder createQuery(String id, String q, String author,
-			String name, String subject, String publisher, String issued, String set,
-			String owner, String t) {
+			String name, String subject, String publisher, String issued,
+			String medium, String set, String owner, String t) {
 		final Map<Parameter, String> parameters =
 				Parameter.select(new ImmutableMap.Builder<Parameter, String>() /*@formatter:off*/
 						.put(Parameter.ID, id)
@@ -140,6 +142,7 @@ public final class Facets extends Controller {
 						.put(Parameter.SUBJECT, subject)
 						.put(Parameter.PUBLISHER, publisher)
 						.put(Parameter.ISSUED, issued)
+						.put(Parameter.MEDIUM, medium)
 						.put(Parameter.SET, set).build());/*@formatter:on*/
 		QueryBuilder query =
 				parameters.isEmpty() ? QueryBuilders.matchAllQuery() : new Search(

--- a/app/controllers/Path.java
+++ b/app/controllers/Path.java
@@ -34,8 +34,8 @@ public final class Path extends Controller {
 	@SuppressWarnings("javadoc")
 	public static Promise<Result> resourceAbout(final String id,
 			final String format, final int from, final int size) {
-		return Api.resource(id, "", "", "", "", "", "", "", format, from, size, "",
-				"", "", false);
+		return Api.resource(id, "", "", "", "", "", "", "", "", format, from, size,
+				"", "", "", false);
 	}
 
 	/** Redirect to {@link #itemAbout(String, String, String, int, int)} */

--- a/app/models/Index.java
+++ b/app/models/Index.java
@@ -37,6 +37,7 @@ public enum Index {
 					.put(Parameter.SUBJECT, new LobidResources.SubjectQuery())
 					.put(Parameter.PUBLISHER, new LobidResources.PublisherQuery())
 					.put(Parameter.ISSUED, new LobidResources.IssuedQuery())
+					.put(Parameter.MEDIUM, new LobidResources.MediumQuery())
 					.put(Parameter.NAME, new LobidResources.NameQuery())
 					.put(Parameter.SET, new LobidResources.SetQuery()).build()),
 	/***/

--- a/app/models/Parameter.java
+++ b/app/models/Parameter.java
@@ -14,7 +14,7 @@ import com.google.common.collect.ImmutableMap;
  */
 @SuppressWarnings("javadoc")
 public enum Parameter {
-	ID, NAME, AUTHOR, SUBJECT, SET, Q, PUBLISHER, ISSUED;
+	ID, NAME, AUTHOR, SUBJECT, SET, Q, PUBLISHER, ISSUED, MEDIUM;
 	/**
 	 * @return The parameter id (the string passed to the API)
 	 */

--- a/app/models/queries/LobidResources.java
+++ b/app/models/queries/LobidResources.java
@@ -189,4 +189,21 @@ public class LobidResources {
 		}
 	}
 
+	/**
+	 * Query the lobid-resources index for a given medium.
+	 */
+	public static class MediumQuery extends AbstractIndexQuery {
+
+		@Override
+		public List<String> fields() {
+			return Arrays.asList("@graph.http://purl.org/dc/terms/medium.@id");
+		}
+
+		@Override
+		public QueryBuilder build(String queryString) {
+			return matchQuery(fields().get(0), queryString);
+		}
+
+	}
+
 }

--- a/conf/routes
+++ b/conf/routes
@@ -32,14 +32,14 @@ GET     /team/pc               controllers.LobidTeam.pc(format ?= "negotiate")
 GET     /team/pc/about         controllers.LobidTeam.pcAbout(id = "http://lobid.org/team/pc", format ?= "negotiate")
 
 # Individual, specialized API routes for different resource types
-GET     /resource                   controllers.Api.resource(id ?= "", q ?= "", name ?= "", author ?= "", subject ?= "", publisher ?= "", issued ?= "", set ?= "", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, owner ?= "", t ?= "", sort ?= "", meta:Boolean?=true)
+GET     /resource                   controllers.Api.resource(id ?= "", q ?= "", name ?= "", author ?= "", subject ?= "", publisher ?= "", issued ?= "", medium ?= "", set ?= "", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, owner ?= "", t ?= "", sort ?= "", meta:Boolean?=true)
 GET     /item                       controllers.Api.item(id ?= "", q ?= "", name ?= "", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, t ?= "", meta:Boolean?=true)
 GET     /organisation               controllers.Api.organisation(id ?= "", q ?= "", name ?= "", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, t ?= "", meta:Boolean?=true)
 GET     /person                     controllers.Api.person(id ?= "", q ?= "", name ?= "", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, t ?= "http://d-nb.info/standards/elementset/gnd#Person", meta:Boolean?=true)
 GET     /subject                    controllers.Api.subject(id ?= "", q ?= "", name ?= "", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, t ?= "")
 
 # Facets
-GET     /resource/facets            controllers.Facets.resource(id ?= "", q?="", author?="", name?="", subject?="", publisher ?= "", issued ?= "", owner?="", set?="", size: Int ?= 50, t ?= "", field)
+GET     /resource/facets            controllers.Facets.resource(id ?= "", q?="", author?="", name?="", subject?="", publisher ?= "", issued ?= "", medium ?= "", owner?="", set?="", size: Int ?= 50, t ?= "", field)
 
 # Path-style routes and `about` redirects
 GET     /resource/:id               controllers.Path.resource(id, format ?= "negotiate", from: Int ?= 0, size: Int ?= 50)

--- a/test/tests/SearchEntitiesNarrowByTypeTests.java
+++ b/test/tests/SearchEntitiesNarrowByTypeTests.java
@@ -21,6 +21,7 @@ public class SearchEntitiesNarrowByTypeTests extends SearchTestsHarness {
 
 	//@formatter:off
 	@Test public void resources() { search("resource?q=*", 25); }
+	@Test public void resourcesMedium() { search("resource?q=*&medium=http://rdvocab.info/termList/RDACarrierType/1020", 1); }
 	@Test public void bibliographicResources() { search("resource?q=*&t=http://purl.org/dc/terms/BibliographicResource", 25); }
 	@Test public void books() { search("resource?q=*&t=http://purl.org/ontology/bibo/Book", 19); }
 	@Test public void journals() { search("resource?q=*&t=http://purl.org/ontology/bibo/Journal", 1); }


### PR DESCRIPTION
See https://github.com/hbz/nwbib/issues/57

Deployed to aither (where we have a small test index that supports this):
http://aither.hbz-nrw.de:7001/resource?name=Faust&medium=http://purl.org/ontology/bibo/AudioDocument
