### PR TITLE
Tweak XML response for `format=full` requests

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -212,7 +212,7 @@ public final class Application extends Controller {
 				appendMabXml(builder, errorMessage, document);
 			final String result = builder.toString().trim();
 			return result.isEmpty() ? notFound(errorMessage + "request") : //
-					ok(documents.size() > 1 ? ("<hits>" + result + "</hits>") : result);
+					documents.size() > 1 ? ok(result) : ok(result).as("text/xml");
 		} catch (IndexMissingException e) {
 			return notFound(e.getMessage());
 		}


### PR DESCRIPTION
- Set content type to text/xml for single response
- Don't wrap multiple results into surrounding element

Deployed to staging: http://test.lobid.org/resource/HT002189125/about?format=source
