### PR TITLE
Add `location` parameter and polygon support for queries and facets

### DIFF
--- a/app/controllers/Api.java
+++ b/app/controllers/Api.java
@@ -49,6 +49,7 @@ public final class Api extends Controller {
 	 * @param type The type of the requested resources
 	 * @param sort The sort order
 	 * @param addQueryInfo If true, add a query info object to the response
+	 * @param location A polygon describing the subject area of the resources
 	 * @return Matching resources
 	 */
 	public static Promise<Result> resource(
@@ -59,7 +60,8 @@ public final class Api extends Controller {
 			final String issued, final String medium, final String set,
 			final String nwbibspatial, final String nwbibsubject,
 			final String format, final int from, final int size, final String owner,
-			final String type, final String sort, final boolean addQueryInfo) {
+			final String type, final String sort, final boolean addQueryInfo,
+			final String location) {
 		Logger
 				.debug(String
 						.format(
@@ -78,7 +80,8 @@ public final class Api extends Controller {
 						.put(Parameter.MEDIUM, medium)
 						.put(Parameter.SET, set)
 						.put(Parameter.NWBIBSPATIAL, nwbibspatial)
-						.put(Parameter.NWBIBSUBJECT, nwbibsubject).build());/*@formatter:on*/
+						.put(Parameter.NWBIBSUBJECT, nwbibsubject)
+						.put(Parameter.LOCATION, location).build());/*@formatter:on*/
 		return Application.search(index, parameters, format, from, size, owner,
 				set, type, sort, addQueryInfo);
 	}
@@ -209,7 +212,7 @@ public final class Api extends Controller {
 		Promise<List<Result>> results =
 				Promise.sequence(
 						resource(id, q, name, "", "", "", "", "", "", "", "", format, from,
-								size, "", "", "", true),
+								size, "", "", "", true, ""),
 						organisation(id, q, name, format, from, size, "", true),
 						person(id, q, name, format, from, size, "", true),
 						subject(id, q, name, format, from, size, ""));

--- a/app/controllers/Facets.java
+++ b/app/controllers/Facets.java
@@ -65,20 +65,21 @@ public final class Facets extends Controller {
 	 * @param size The number of results to receive
 	 * @param t The type of the requested resources
 	 * @param field The index field to get facets for
+	 * @param location A polygon describing the subject area of the resources
 	 * @return Returns the facets for the field and the given restrictions
 	 */
 	public static Promise<Result> resource(String id, String q, String author,
 			String name, String subject, String publisher, String issued,
 			String medium, String owner, String set, String nwbibspatial,
-			String nwbibsubject, int size, String t, String field) {
+			String nwbibsubject, int size, String t, String field, String location) {
 		if (size > 1500) {
 			return Promise
 					.promise(() -> badRequest("Parameter 'size' must be <= 1500"));
 		}
 		String key =
-				String.format("facets.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s",
+				String.format("facets.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s",
 						id, q, author, name, subject, publisher, issued, medium, owner,
-						set, nwbibspatial, nwbibsubject, size, field, t);
+						set, nwbibspatial, nwbibsubject, size, field, t, location);
 		Result cachedResult = (Result) Cache.get(key);
 		if (cachedResult != null) {
 			return Promise.promise(() -> cachedResult);
@@ -86,7 +87,7 @@ public final class Facets extends Controller {
 		Promise<Result> result =
 				createJsonResponse(getElasticsearchFacets(id, q, author, name, subject,
 						publisher, issued, medium, owner, set, nwbibspatial, nwbibsubject,
-						field, size, t));
+						field, size, t, location));
 		result.onRedeem(r -> Cache.set(key, r, ONE_DAY));
 		return result;
 	}
@@ -115,13 +116,15 @@ public final class Facets extends Controller {
 	private static Promise<org.elasticsearch.search.facet.Facets> getElasticsearchFacets(
 			String id, String q, String author, String name, String subject,
 			String publisher, String issued, String medium, String owner, String set,
-			String nwbibspatial, String nwbibsubject, String field, int size, String t) {
+			String nwbibspatial, String nwbibsubject, String field, int size,
+			String t, String location) {
 		Promise<org.elasticsearch.search.facet.Facets> promise =
 				Promise.promise(
 						() -> {
 							QueryBuilder query =
 									createQuery(id, q, author, name, subject, publisher, issued,
-											medium, set, nwbibspatial, nwbibsubject, owner, t);
+											medium, set, nwbibspatial, nwbibsubject, owner, t,
+											location);
 							SearchRequestBuilder req =
 									createRequest(owner, field, query, size);
 							long start = System.currentTimeMillis();
@@ -140,7 +143,7 @@ public final class Facets extends Controller {
 	private static QueryBuilder createQuery(String id, String q, String author,
 			String name, String subject, String publisher, String issued,
 			String medium, String set, String nwbibspatial, String nwbibsubject,
-			String owner, String t) {
+			String owner, String t, String location) {
 		final Map<Parameter, String> parameters =
 				Parameter.select(new ImmutableMap.Builder<Parameter, String>() /*@formatter:off*/
 						.put(Parameter.ID, id)
@@ -153,7 +156,8 @@ public final class Facets extends Controller {
 						.put(Parameter.MEDIUM, medium)
 						.put(Parameter.SET, set)
 						.put(Parameter.NWBIBSPATIAL, nwbibspatial)
-						.put(Parameter.NWBIBSUBJECT, nwbibsubject).build());/*@formatter:on*/
+						.put(Parameter.NWBIBSUBJECT, nwbibsubject)
+						.put(Parameter.LOCATION, location).build());/*@formatter:on*/
 		QueryBuilder query =
 				parameters.isEmpty() ? QueryBuilders.matchAllQuery() : new Search(
 						parameters, Index.LOBID_RESOURCES).owner(owner).type(t)

--- a/app/controllers/Path.java
+++ b/app/controllers/Path.java
@@ -35,7 +35,7 @@ public final class Path extends Controller {
 	public static Promise<Result> resourceAbout(final String id,
 			final String format, final int from, final int size) {
 		return Api.resource(id, "", "", "", "", "", "", "", "", "", "", format,
-				from, size, "", "", "", false);
+				from, size, "", "", "", false, "");
 	}
 
 	/** Redirect to {@link #itemAbout(String, String, String, int, int)} */

--- a/app/models/Index.java
+++ b/app/models/Index.java
@@ -42,7 +42,7 @@ public enum Index {
 					.put(Parameter.SET, new LobidResources.SetQuery())
 					.put(Parameter.NWBIBSPATIAL, new LobidResources.NwBibSpatialQuery())
 					.put(Parameter.NWBIBSUBJECT, new LobidResources.NwBibSubjectQuery())
-					.build()),
+					.put(Parameter.LOCATION, new LobidResources.LocationQuery()).build()),
 	/***/
 	LOBID_ORGANISATIONS("lobid-organisations", "json-ld-lobid-orgs",
 			new ImmutableMap.Builder<Parameter, AbstractIndexQuery>()/* @formatter:off */

--- a/app/models/Parameter.java
+++ b/app/models/Parameter.java
@@ -14,7 +14,7 @@ import com.google.common.collect.ImmutableMap;
  */
 @SuppressWarnings("javadoc")
 public enum Parameter {
-	ID, NAME, AUTHOR, SUBJECT, SET, Q, PUBLISHER, ISSUED, MEDIUM, NWBIBSPATIAL, NWBIBSUBJECT;
+	ID, NAME, AUTHOR, SUBJECT, SET, Q, PUBLISHER, ISSUED, MEDIUM, NWBIBSPATIAL, NWBIBSUBJECT, LOCATION;
 	/**
 	 * @return The parameter id (the string passed to the API)
 	 */

--- a/app/models/queries/LobidResources.java
+++ b/app/models/queries/LobidResources.java
@@ -10,6 +10,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.elasticsearch.index.query.FilterBuilder;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.GeoPolygonFilterBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder.Operator;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
@@ -244,6 +247,38 @@ public class LobidResources {
 		@Override
 		public QueryBuilder build(String queryString) {
 			return multiMatchQuery(queryString, fields().toArray(new String[] {}));
+		}
+
+	}
+
+	/**
+	 * Query the lobid-resources set for results in a given polygon.
+	 */
+	public static class LocationQuery extends AbstractIndexQuery {
+
+		@Override
+		public List<String> fields() {
+			return Arrays
+					.asList("@graph.http://purl.org/lobid/lv#subjectLocation.@value");
+		}
+
+		@Override
+		public QueryBuilder build(String queryString) {
+			return QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(),
+					polygonFilter(queryString));
+		}
+
+		private FilterBuilder polygonFilter(String location) {
+			GeoPolygonFilterBuilder filter =
+					FilterBuilders.geoPolygonFilter("json-ld-lobid." + fields().get(0));
+			String[] points = location.split(" ");
+			for (String point : points) {
+				String[] latLon = point.split(",");
+				filter =
+						filter.addPoint(Double.parseDouble(latLon[0].trim()),
+								Double.parseDouble(latLon[1].trim()));
+			}
+			return filter;
 		}
 
 	}

--- a/conf/routes
+++ b/conf/routes
@@ -32,14 +32,14 @@ GET     /team/pc               controllers.LobidTeam.pc(format ?= "negotiate")
 GET     /team/pc/about         controllers.LobidTeam.pcAbout(id = "http://lobid.org/team/pc", format ?= "negotiate")
 
 # Individual, specialized API routes for different resource types
-GET     /resource                   controllers.Api.resource(id ?= "", q ?= "", name ?= "", author ?= "", subject ?= "", publisher ?= "", issued ?= "", medium ?= "", set ?= "", nwbibspatial?="", nwbibsubject?="", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, owner ?= "", t ?= "", sort ?= "", meta:Boolean?=true)
+GET     /resource                   controllers.Api.resource(id ?= "", q ?= "", name ?= "", author ?= "", subject ?= "", publisher ?= "", issued ?= "", medium ?= "", set ?= "", nwbibspatial?="", nwbibsubject?="", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, owner ?= "", t ?= "", sort ?= "", meta:Boolean?=true, location ?= "")
 GET     /item                       controllers.Api.item(id ?= "", q ?= "", name ?= "", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, t ?= "", meta:Boolean?=true)
 GET     /organisation               controllers.Api.organisation(id ?= "", q ?= "", name ?= "", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, t ?= "", meta:Boolean?=true)
 GET     /person                     controllers.Api.person(id ?= "", q ?= "", name ?= "", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, t ?= "http://d-nb.info/standards/elementset/gnd#Person", meta:Boolean?=true)
 GET     /subject                    controllers.Api.subject(id ?= "", q ?= "", name ?= "", format ?= "negotiate", from: Int ?= 0, size: Int ?= 50, t ?= "")
 
 # Facets
-GET     /resource/facets            controllers.Facets.resource(id ?= "", q?="", author?="", name?="", subject?="", publisher ?= "", issued ?= "", medium ?= "", owner?="", set?="", nwbibspatial?="", nwbibsubject?="", size: Int ?= 50, t ?= "", field)
+GET     /resource/facets            controllers.Facets.resource(id ?= "", q?="", author?="", name?="", subject?="", publisher ?= "", issued ?= "", medium ?= "", owner?="", set?="", nwbibspatial?="", nwbibsubject?="", size: Int ?= 50, t ?= "", field, location ?= "")
 
 # Path-style routes and `about` redirects
 GET     /resource/:id               controllers.Path.resource(id, format ?= "negotiate", from: Int ?= 0, size: Int ?= 50)


### PR DESCRIPTION
See https://github.com/hbz/lobid/issues/88

Pass space delimited `lat,lon` points describing the polygon.

Deployed to staging:

http://test.lobid.org/resource?format=full&author=136378153&location=52,6.5+52,7+51,6.5+51,7
http://test.lobid.org/resource/facets?field=@graph.@type&location=52,6.5+52,7+51,6.5+51,7
