### PR TITLE
Add type "cross fields" to multi match queries

### DIFF
--- a/app/models/queries/LobidResources.java
+++ b/app/models/queries/LobidResources.java
@@ -83,6 +83,7 @@ public class LobidResources {
 		@Override
 		public QueryBuilder build(final String queryString) {
 			return multiMatchQuery(queryString, fields().toArray(new String[] {}))
+					.type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
 					.operator(Operator.AND);
 		}
 

--- a/test/tests/SearchResourceCombineFieldsTests.java
+++ b/test/tests/SearchResourceCombineFieldsTests.java
@@ -21,7 +21,7 @@ public class SearchResourceCombineFieldsTests extends SearchTestsHarness {
 
 	/*@formatter:off@*/
 	@Test public void searchName(){search("resource?name=der", 4);}
-	@Test public void searchAltName(){search("resource?name=Grenzdimensionen", 1);}
+	@Test public void searchAltName(){search("resource?name=Grenzdimensionen Erfahrung", 1);}
 	@Test public void searchNameAndAuthor(){search("resource?name=der&author=edmund", 1);}
 	@Test public void searchNameAndSubject(){search("resource?name=der&subject=4414195-6", 1);}
 	@Test public void searchAuthor(){search("resource?author=hu", 2);}


### PR DESCRIPTION
See hbz/nwbib#87.

"Cross_fields" treats fields with the same analyzer as though they were one big field. Looks for each word in any field.

* add test