### PR TITLE
Remove hyphen from isbn & issn queries

### DIFF
--- a/app/models/queries/LobidResources.java
+++ b/app/models/queries/LobidResources.java
@@ -179,15 +179,20 @@ public class LobidResources {
 
 		@Override
 		public QueryBuilder build(final String queryString) {
-			return multiMatchQuery(lobidResourceQueryString(queryString),
+			return multiMatchQuery(normalizedLobidResourceIdQueryString(queryString),
 					fields().toArray(new String[] {})).operator(Operator.AND);
 		}
 	}
 
-	private static String lobidResourceQueryString(final String queryString) {
+	private static String normalizedLobidResourceIdQueryString(
+			final String queryString) {
+		String normalizedQueryString = queryString.replaceAll(" ", "");
+		if (normalizedQueryString.matches("\"?\\d.*\"?")) {
+			normalizedQueryString = normalizedQueryString.replaceAll("-", "");
+		}
 		final String hbzId = "\\p{L}+\\d+(-.+)?";
-		return queryString.matches(hbzId) ? "http://lobid.org/resource/"
-				+ queryString : queryString;
+		return normalizedQueryString.matches(hbzId) ? "http://lobid.org/resource/"
+				+ normalizedQueryString : normalizedQueryString;
 	}
 
 	/**

--- a/test/tests/SearchTests.java
+++ b/test/tests/SearchTests.java
@@ -128,6 +128,7 @@ public class SearchTests extends SearchTestsHarness {
 	@Test public void searchResByIdZdbUrl1() { searchResById("http://lobid.org/resource/ZDB2615620-9"); }
 	@Test public void searchResByIdZdbUrl2() { searchResById("http://lobid.org/resource/ZDB2530091-X"); }
 	@Test public void searchResByIdISBN() { searchResById("0940450003"); }
+	@Test public void searchResByIdIsbnConsistingOfHyphenAndSpaceISBN() { searchResById("0 080 238-70x"); }
 	@Test public void searchResByIdUrn() { searchResById("urn:nbn:de:hbz:929:02-1035"); }
 	/*@formatter:on*/
 


### PR DESCRIPTION
See #44.

This issue corresponds with https://github.com/lobid/lodmill/pull/649.

Since only isbn & issn are starting with digits its save to
remove the hyphen from these strings. Amongst other , URNs
musn't be changed in this way - and they won't.