### PR TITLE
Use internal_id and phrase query to get item URI

### DIFF
--- a/app/models/queries/LobidItems.java
+++ b/app/models/queries/LobidItems.java
@@ -48,7 +48,7 @@ public class LobidItems {
 
 		@Override
 		public List<String> fields() {
-			return Arrays.asList("@graph.@id");
+			return Arrays.asList("internal_id");
 		}
 
 		PercentEscaper percentEscaper = new PercentEscaper(
@@ -59,8 +59,8 @@ public class LobidItems {
 			final String itemPrefix = "http://lobid.org/item/";
 			final String shortId = queryString.replace(itemPrefix, "");
 			// The Lobid item IDs contain escaped url fragments
-			return matchQuery(fields().get(0),
-					itemPrefix + percentEscaper.escape(shortId));
+			return QueryBuilders.matchPhraseQuery(fields().get(0), itemPrefix
+					+ percentEscaper.escape(shortId));
 		}
 	}
 


### PR DESCRIPTION
See hbz/lobid#141.

Not exactly sure why the old settings weren't working anymore.
Mind that it broke against an index where the @graph.@id of the
items wasn't used yet (as might the history of lodmill-ld suggest,
see 7f0b3bbe2f825268fc06b286938fc09f03b943b8 committed at 2015-03-06
in lodmill-ld) as we switched back to an old index because of the
hadoop enrichment issue, see #139).
This phrase query against the internal id is working fine, though.