### PR TITLE
Fix searching author

### DIFF
--- a/app/models/queries/AbstractIndexQuery.java
+++ b/app/models/queries/AbstractIndexQuery.java
@@ -47,7 +47,7 @@ public abstract class AbstractIndexQuery {
 			final String term =
 					search.startsWith("http") ? search : "http://d-nb.info/gnd/" + search;
 			query =
-					multiMatchQuery(term, fields().subList(3, fields().toArray().length)
+					multiMatchQuery(term, fields().subList(4, fields().toArray().length)
 							.toArray(new String[] {}));
 		} else {
 			query = nameMatchQuery(search);


### PR DESCRIPTION
See #163.

Bug introduced with ba66ee2f65ff273182cfd67641642d9dc8d1474a.
So one value field would be also queried, amongst the id fields.

Increasing the list parameter to start at '4' only id fields are queried.