### PR TITLE
Allow only one scroll at a time

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -128,6 +128,11 @@ public final class Application extends Controller {
 			return badRequestPromise(e.getMessage());
 		}
 		if (scroll) {
+			if (search.doingScrollScanNow()) {
+				return Promise
+						.pure(status(Http.Status.CONFLICT,
+								"Already doing a scroll scan. Only one permitted. Please try again later."));
+			}
 			Serialization serialization = getSerialization(request());
 			if (serialization == null)
 				return Promise.pure(status(Http.Status.NOT_ACCEPTABLE,

--- a/app/models/Search.java
+++ b/app/models/Search.java
@@ -246,19 +246,21 @@ public class Search {
 				executorService.execute(new Runnable() {
 					@Override
 					public void run() {
-						if (doingScrollScanNow) {
-							getMessageOut()
-									.write(
-											"Already doing a scroll scan. Only one permitted. Please try again later.");
-						} else {
-							doingScrollScanNow = true;
-							bulk(request, serialization);
-						}
+						doingScrollScanNow = true;
+						bulk(request, serialization);
 					}
 				});
 				executorService.shutdown();
 			}
 		};
+	}
+
+	/**
+	 * 
+	 * @return if a scroll scan is done right now
+	 */
+	public boolean doingScrollScanNow() {
+		return doingScrollScanNow;
 	}
 
 	private void bulk(final Request request, final Serialization serialization) {

--- a/app/views/api.scala.html
+++ b/app/views/api.scala.html
@@ -154,8 +154,9 @@
 		</tr>
 	</table>
 
-	<h2>Pagination and Limits</h2>
-	<p>All endpoints support pagination via <code>from</code> and <code>size</code> parameters specifying the index to start the result set from (default is 0, must be >= 0), and the size of the result set (default is 50, must be <= 100). Sample request: <a href="/organisation?name=Universität&from=10&size=5&format=ids">/organisation?name=Universität&from=10&size=5&format=ids</a>.</p>
+	<h2>Pagination and Limits and Bulk Downloads</h2>
+	<p>All endpoints support pagination via <code>from</code> and <code>size</code> parameters specifying the index to start the result set from (default is 0, must be >= 0), and the size of the result set (default is 50, must be <= 100). Sample request: <a href="/organisation?name=Universität&from=10&size=5&format=ids">/organisation?name=Universität&from=10&size=5&format=ids</a>.<br/>
+However, f you want to receive all hits or get loads of data it is way faster and more coherent to use the boolean <code>scroll</code> parameter. Sample request: <a href="resource?set=edoweb&scroll=true">/resource?set=edoweb&scroll=true</a>. Note that the <code>format</code> parameter doesn't work when scrolling. Note also that only one scrolling at the same time is allowed for now.</p>
 
 	<h2>Content Negotiation</h2>
 	<p>To return different RDF serializations as the result format (default is JSON-LD), you can specify an accept header, e.g. for N-Triples:</p>


### PR DESCRIPTION
* add usage explanation to  API overview page

See #176.