### PR TITLE
Validate parameters when using `scroll=true`.

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -138,8 +138,13 @@ public final class Application extends Controller {
 				return Promise.pure(status(Http.Status.NOT_ACCEPTABLE,
 						HTTP_CODE_406_MESSAGE));
 			response().setHeader("Transfer-Encoding", "Chunked");
-			return Promise
-					.pure(ok(search.executeScrollScan(request(), serialization)));
+			try {
+				return Promise.pure(ok(
+						search.executeScrollScan(request(), serialization)));
+			} catch (IllegalArgumentException e) {
+				Logger.error(e.getMessage(), e);
+				return badRequestPromise(e.getMessage());
+			}
 		}
 		try {
 			List<Document> docs = search.documents();

--- a/app/models/Search.java
+++ b/app/models/Search.java
@@ -238,6 +238,7 @@ public class Search {
 	 */
 	public Chunks<String> executeScrollScan(final Request request,
 			final Serialization serialization) {
+		validateSearchParameters();
 		return new StringChunks() {
 			@Override
 			public void onReady(Chunks.Out<String> out) {

--- a/test/tests/SearchTests.java
+++ b/test/tests/SearchTests.java
@@ -223,6 +223,19 @@ public class SearchTests extends SearchTestsHarness {
 		});
 	}
 
+	@Test
+	public void returnScrollSizeBadRequest() {
+		running(fakeApplication(), new Runnable() {
+			@Override
+			public void run() {
+				assertThat(status(
+					route(fakeRequest(GET, "/resource?q=*&size=10000&scroll=true")
+						.withHeader("Accept", "application/rdf+xml"))))
+							.isEqualTo(BAD_REQUEST);
+			}
+		});
+	}
+
 	/*@formatter:off*/
 	@Test public void searchViaModelBirth0() { findOneBy("Theo Hundt"); }
 	@Test public void searchViaModelBirth1() { findOneBy("Hundt, Theo"); }


### PR DESCRIPTION
The new chunked response uses a different code path that skipped parameter validation. This allowed requests with unlimited size, see included test for an example.