### PR TITLE
Set WordQuery to `MultiMatchQueryBuilder.Type.CROSS_FIELDS`

### DIFF
--- a/app/models/queries/LobidResources.java
+++ b/app/models/queries/LobidResources.java
@@ -336,6 +336,7 @@ public class LobidResources {
 		@Override
 		public QueryBuilder build(String queryString) {
 			return multiMatchQuery(queryString, fields().toArray(new String[] {}))
+					.type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
 					.operator(Operator.AND);
 		}
 	}

--- a/test/tests/ApiTests.java
+++ b/test/tests/ApiTests.java
@@ -89,6 +89,8 @@ public class ApiTests {
 				{ "resource?word=Kohlenstoff", /* -> */"PROTON" },
 				{ "resource?word=Weihnachtslied&set=NWBib",
 						/* -> */"Wann en Kölle de Chress-Stäne blöhe" },
+				{ "resource?word=Weihnachtslied+Paula+Hiertz&set=NWBib",
+						/* -> */"Wann en Kölle de Chress-Stäne blöhe" },
 				/*-------------------*/
 				/* GET /organisation */
 				/*-------------------*/


### PR DESCRIPTION
Fixes an issue reported during review by @acka47.

See https://github.com/hbz/nwbib/issues/110