### PR TITLE
Remove old `api` subdomain from `application.url` config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -2,7 +2,7 @@
 # ~~~~~
 
 application.version="1.17.0"
-application.url="http://api.lobid.org" # staging: "http://staging.api.lobid.org"
+application.url="http://lobid.org" # staging: "http://test.lobid.org"
 application.index.suffix="" # staging: "-staging"
 application.es.server="193.30.112.172" # staging: "193.30.112.84"
 application.es.cluster="quaoar" # staging: "aither"


### PR DESCRIPTION
See #211