### PR TITLE
Use `hbzId` field for source queries and UI tab

### DIFF
--- a/app/models/Index.java
+++ b/app/models/Index.java
@@ -70,7 +70,8 @@ public enum Index {
 	LOBID_COLLECTIONS("lobid-collections", "json-ld-lobid-collection",
 			new ImmutableMap.Builder<Parameter, AbstractIndexQuery>().build()); /*@formatter:on*/
 
-	static final Config CONFIG =
+	/** Access application config data. */
+	public static final Config CONFIG =
 			ConfigFactory.parseFile(new File("conf/application.conf")).resolve();
 	private String id; // NOPMD
 	private String type;

--- a/app/views/docs.scala.html
+++ b/app/views/docs.scala.html
@@ -41,12 +41,12 @@
 		  <div class="tab-pane" id="@id-nt"><pre>@doc.as(Format.N_TRIPLE)</pre></div>
 		  <div class="tab-pane" id="@id-ttl"><pre>@doc.as(Format.TURTLE)</pre></div>
 		  @if(index==models.Index.LOBID_RESOURCES) {
-		    @defining(Await.result(
-		    WS.url(doc.getId+"?format=source").get().map(x=>(x.status,x.body)), 5.second)){case (status,body)=>
+		    @defining(Index.CONFIG.getString("hbz01.api") + "/" + (Json.parse(doc.getSource)\\"hbzId")(0).as[String]) { hbz01Url =>
+		    @defining(Await.result(WS.url(hbz01Url).get().map(x=>(x.status,x.body)), 5.second)){case (status,body)=>
 		    <div class="tab-pane" id="@id-src"><pre>@status match {
 					case Http.Status.OK => {@(new PrettyPrinter(80,2).format(XML.loadString(body)))}
 					case _ => {@body}}</pre></div>
-		    }
+		    }}
 		  }
 		</div>
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,6 +3,7 @@
 
 application.version="1.17.0"
 application.url="http://lobid.org" # staging: "http://test.lobid.org"
+hbz01.api="http://beta.lobid.org/hbz01"
 application.index.suffix="" # staging: "-staging"
 application.es.server="193.30.112.172" # staging: "193.30.112.84"
 application.es.cluster="quaoar" # staging: "aither"


### PR DESCRIPTION
This fixes issues e.g. with ZDB resources, see https://github.com/hbz/mabxml-elasticsearch/issues/11

Switch to using hbz01 web API instead of direct index access.