### PR TITLE
Limit scroll download

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -131,10 +131,10 @@ public final class Application extends Controller {
 				return Promise.pure(status(Http.Status.CONFLICT,
 						"Already doing a scroll scan. Only one permitted. Please try again later."));
 			}
-			if (search.getTotalHits() > Search.getAllowedMaxScrollHits()) {
+			if (search.getTotalHits() > Search.MAX_SCROLL_HITS) {
 				return Promise.pure(status(Http.Status.REQUEST_ENTITY_TOO_LARGE,
 						"The requested entity is too large. Not more than "
-								+ Search.getAllowedMaxScrollHits() + " hits are allowed."));
+								+ Search.MAX_SCROLL_HITS + " hits are allowed."));
 			}
 			Serialization serialization = getSerialization(request());
 			if (serialization == null)

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -131,6 +131,11 @@ public final class Application extends Controller {
 				return Promise.pure(status(Http.Status.CONFLICT,
 						"Already doing a scroll scan. Only one permitted. Please try again later."));
 			}
+			if (search.getTotalHits() > Search.getAllowedMaxScrollHits()) {
+				return Promise.pure(status(Http.Status.REQUEST_ENTITY_TOO_LARGE,
+						"The requested entity is too large. Not more than "
+								+ Search.getAllowedMaxScrollHits() + " hits are allowed."));
+			}
 			Serialization serialization = getSerialization(request());
 			if (serialization == null)
 				return Promise

--- a/app/models/Search.java
+++ b/app/models/Search.java
@@ -83,6 +83,7 @@ public class Search {
 	private String type = "";
 	private String sort = "";
 	private String scroll = "";
+	private static final long maxScrollHits = 3000000;
 
 	private List<Document> documents = null;
 	private Long hitCount = null;
@@ -240,6 +241,13 @@ public class Search {
 	public Search scroll(final String scrollValue) {
 		this.scroll = scrollValue;
 		return this;
+	}
+
+	/**
+	 * @return number of hits of the query
+	 */
+	public long getTotalHits() {
+		return (startInitialResponse().getHits().getTotalHits());
 	}
 
 	/**
@@ -486,5 +494,16 @@ public class Search {
 
 	private void setMessageOut(final Chunks.Out<String> messageOut) {
 		this.messageOut = messageOut;
+	}
+
+	/**
+	 * As there is a memory issue within Promise we musn't allow data > RAM. As
+	 * experience shows, this is around 4 M docs (dependig on the serialisation).
+	 * 
+	 * @return maximum of allowed hits for a scroll search
+	 */
+
+	public static long getAllowedMaxScrollHits() {
+		return maxScrollHits;
 	}
 }

--- a/app/models/Search.java
+++ b/app/models/Search.java
@@ -83,7 +83,12 @@ public class Search {
 	private String type = "";
 	private String sort = "";
 	private String scroll = "";
-	private static final long maxScrollHits = 3000000;
+
+	/**
+	 * As there is a memory issue within Promise we musn't allow data > RAM. As
+	 * experience shows, this is around 4 M docs (dependig on the serialisation).
+	 */
+	public static final int MAX_SCROLL_HITS = 3000000;
 
 	private List<Document> documents = null;
 	private Long hitCount = null;
@@ -496,14 +501,4 @@ public class Search {
 		this.messageOut = messageOut;
 	}
 
-	/**
-	 * As there is a memory issue within Promise we musn't allow data > RAM. As
-	 * experience shows, this is around 4 M docs (dependig on the serialisation).
-	 * 
-	 * @return maximum of allowed hits for a scroll search
-	 */
-
-	public static long getAllowedMaxScrollHits() {
-		return maxScrollHits;
-	}
 }

--- a/app/views/api.scala.html
+++ b/app/views/api.scala.html
@@ -156,8 +156,8 @@
 
 	<h2>Pagination and Limits and Bulk Downloads</h2>
 	<p>All endpoints support pagination via <code>from</code> and <code>size</code> parameters specifying the index to start the result set from (default is 0, must be >= 0), and the size of the result set (default is 50, must be <= 100). Sample request: <a href="/organisation?name=Universität&from=10&size=5&format=ids">/organisation?name=Universität&from=10&size=5&format=ids</a>.<br/>
-However, if you want to receive all hits or get loads of data it is way faster and more coherent to use the boolean <code>scroll</code> parameter. You may even give a 8 digit date to get only the metadata of resources that changed (created or modificated) since this time. Sample request: <pre>curl -L --header "Accept: application/ld+json" "http://lobid.org/resource?set=nwbib&scroll=20150401"</pre></p>
-<p>Note that the <code>format</code> parameter doesn't work when scrolling. Note also that only one scrolling at the same time is allowed for now.</p>
+However, if you want to receive all hits or get loads of data it is way faster and more coherent to use the boolean <code>scroll</code> parameter. You may even give a 8 digit date to get only the metadata of resources that changed (created or modificated) since this time. Sample request: <pre>curl --header "Accept: application/ld+json" --header "Accept-Encoding: gzip" "http://lobid.org/resource?set=nwbib&scroll=20150301"</pre></p>
+<p>Note that the <code>format</code> parameter doesn't work when scrolling. Note also to request gzip compression to speed up getting loads of data.</p>
 
 	<h2>Content Negotiation</h2>
 	<p>To return different RDF serializations as the result format (default is JSON-LD), you can specify an accept header, e.g. for N-Triples:</p>


### PR DESCRIPTION
Because of #188 (memory issue with `Promise`) we better limit the amount of data that can be loaded.