### PR TITLE
Add `id` attributes for fragment links to API sections

### DIFF
--- a/app/views/api.scala.html
+++ b/app/views/api.scala.html
@@ -154,17 +154,17 @@
 		</tr>
 	</table>
 
-	<h2>Pagination and Limits and Bulk Downloads</h2>
+	<h2 id="pagination+limits+bulk-downloads" style="padding-top: 50px; margin-top: -50px;">Pagination and Limits and Bulk Downloads</h2>
 	<p>All endpoints support pagination via <code>from</code> and <code>size</code> parameters specifying the index to start the result set from (default is 0, must be >= 0), and the size of the result set (default is 50, must be <= 100). Sample request: <a href="/organisation?name=Universität&from=10&size=5&format=ids">/organisation?name=Universität&from=10&size=5&format=ids</a>.<br/>
 However, if you want to receive all hits or get loads of data it is way faster and more coherent to use the boolean <code>scroll</code> parameter. You may even give a 8 digit date to get only the metadata of resources that changed (created or modificated) since this time. Sample request: <pre>curl -L --header "Accept: application/ld+json" "http://lobid.org/resource?set=nwbib&scroll=20150401"</pre></p>
 <p>Note that the <code>format</code> parameter doesn't work when scrolling. Note also that only one scrolling at the same time is allowed for now.</p>
 
-	<h2>Content Negotiation</h2>
+	<h2 id="content-negotiation" style="padding-top: 50px; margin-top: -50px;">Content Negotiation</h2></a>
 	<p>To return different RDF serializations as the result format (default is JSON-LD), you can specify an accept header, e.g. for N-Triples:</p>
 	<pre>curl -L --header "Accept: text/plain" http://api.lobid.org/resource?id=HT002189125</pre>
 	<p>Currently supported: @Serialization.values().map((s:Serialization) => s.name + " " + s.getTypes).mkString(", ")</p>
 
-	<h2>Sample usage: auto suggest</h2>
+	<h2 id="auto-suggest-examples" style="padding-top: 50px; margin-top: -50px;">Sample usage: auto suggest</h2>
 
 	<ul class="nav nav-tabs" id="samples">
 		<li><a href="#sample-person" data-toggle="tab"><code>/person</code></a></li>


### PR DESCRIPTION
See #236