### PR TITLE
Change links to be ssl ready

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -22,7 +22,7 @@
   <body>
     <div class="masthead">
         <div id="lobid">
-            <img src="http://lobid.org/images/butterfly.png"/>
+            <img src="@routes.Assets.at("/public", "images/butterfly.png")"/>
         </div>
     </div>
     <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -51,7 +51,7 @@
     <hr/>
     <div class="footer">
       <p>lobid | running on cluster @Search.ES_CLUSTER_NAME |
-        a service of <a href="/organisation/DE-605">hbz — Hochschulbibliothekszentrum des Landes NRW</a> | <a href="http://www.hbz-nrw.de/impressum">imprint</a></p>
+        a service of <a href="/organisation/DE-605">hbz — Hochschulbibliothekszentrum des Landes NRW</a> | <a href="https://www.hbz-nrw.de/impressum">imprint</a></p>
     </div>
   </body>
 </html>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -8,7 +8,7 @@ body {
 
 .masthead #lobid {
 	width: 100%;
-	background-image: url('http://lobid.org/images/clouds.jpg');
+	background-image: url('../images/clouds.jpg');
 	background-repeat: repeat-x;
 }
 


### PR DESCRIPTION
See #182.

- add relative URLs to be deployable with or without ssl
- link to https version of hbz-nrw.de

The latter wouldn't be needed but since it is agreed to use https as default
we should link to https if it's available.