### PR TITLE
Support single point in location queries

### DIFF
--- a/app/models/queries/LobidResources.java
+++ b/app/models/queries/LobidResources.java
@@ -298,7 +298,7 @@ public class LobidResources {
 	}
 
 	/**
-	 * Query the lobid-resources set for results in a given polygon.
+	 * Query the lobid-resources set for results in a given point or polygon.
 	 */
 	public static class LocationQuery extends AbstractIndexQuery {
 
@@ -315,15 +315,25 @@ public class LobidResources {
 		}
 
 		private FilterBuilder polygonFilter(String location) {
-			GeoPolygonFilterBuilder filter =
-					FilterBuilders.geoPolygonFilter("json-ld-lobid." + fields().get(0));
 			String[] points = location.split(" ");
-			for (String point : points) {
-				String[] latLon = point.split(",");
-				filter = filter.addPoint(Double.parseDouble(latLon[0].trim()),
-						Double.parseDouble(latLon[1].trim()));
+			String field = "json-ld-lobid." + fields().get(0);
+			FilterBuilder result = null;
+			if (points.length == 1) {
+				String[] latLon = points[0].split(",");
+				result = FilterBuilders.geoDistanceFilter(field)
+						.point(Double.parseDouble(latLon[0].trim()),
+								Double.parseDouble(latLon[1].trim()))
+						.distance("100m");
+			} else {
+				GeoPolygonFilterBuilder filter = FilterBuilders.geoPolygonFilter(field);
+				for (String point : points) {
+					String[] latLon = point.split(",");
+					filter = filter.addPoint(Double.parseDouble(latLon[0].trim()),
+							Double.parseDouble(latLon[1].trim()));
+				}
+				result = filter;
 			}
-			return filter;
+			return result;
 		}
 
 	}

--- a/app/models/queries/LobidResources.java
+++ b/app/models/queries/LobidResources.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.GeoDistanceFilterBuilder;
 import org.elasticsearch.index.query.GeoPolygonFilterBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder.Operator;
@@ -319,11 +320,11 @@ public class LobidResources {
 			String field = "json-ld-lobid." + fields().get(0);
 			FilterBuilder result = null;
 			if (points.length == 1) {
-				String[] latLon = points[0].split(",");
-				result = FilterBuilders.geoDistanceFilter(field)
-						.point(Double.parseDouble(latLon[0].trim()),
-								Double.parseDouble(latLon[1].trim()))
-						.distance("100m");
+				result = geoDistanceFilter(field, points[0].split(","));
+			} else if (points.length == 2) {
+				result = FilterBuilders.boolFilter()
+						.should(geoDistanceFilter(field, points[0].split(",")))
+						.should(geoDistanceFilter(field, points[1].split(",")));
 			} else {
 				GeoPolygonFilterBuilder filter = FilterBuilders.geoPolygonFilter(field);
 				for (String point : points) {
@@ -334,6 +335,14 @@ public class LobidResources {
 				result = filter;
 			}
 			return result;
+		}
+
+		private static GeoDistanceFilterBuilder geoDistanceFilter(String field,
+				String[] latLon) {
+			return FilterBuilders.geoDistanceFilter(field)
+					.point(Double.parseDouble(latLon[0].trim()),
+							Double.parseDouble(latLon[1].trim()))
+					.distance("100m");
 		}
 
 	}

--- a/test/tests/ApiTests.java
+++ b/test/tests/ApiTests.java
@@ -103,6 +103,7 @@ public class ApiTests extends SearchTestsHarness {
 						/* -> */"Jahresabschluss" },
 				{ "resource?corporation=Deutscher+Werkbund",
 						/* -> */"Einmischen und mitgestalten" },
+				{ "resource?location=50.9894,7.50167", /* -> */"Monatshefte" },
 				/*-------------------*/
 				/* GET /organisation */
 				/*-------------------*/

--- a/test/tests/ApiTests.java
+++ b/test/tests/ApiTests.java
@@ -104,6 +104,10 @@ public class ApiTests extends SearchTestsHarness {
 				{ "resource?corporation=Deutscher+Werkbund",
 						/* -> */"Einmischen und mitgestalten" },
 				{ "resource?location=50.9894,7.50167", /* -> */"Monatshefte" },
+				{ "resource?location=50.9894,7.50167+50.942222222222,6.9577777777778",
+						/* -> */"Monatshefte" },
+				{ "resource?location=50.9894,7.50167+50.942222222222,6.9577777777778",
+						/* -> */"Weihnachtslied" },
 				/*-------------------*/
 				/* GET /organisation */
 				/*-------------------*/


### PR DESCRIPTION
Required for queries based on `subjectLocation` coordinates.

See https://github.com/hbz/nwbib/issues/139

Deployed to staging: http://test.lobid.org/resource?location=50.9894,7.50167&format=full