### PR TITLE
Support multi-value subject queries only for URIs or GND IDs

### DIFF
--- a/app/models/queries/LobidResources.java
+++ b/app/models/queries/LobidResources.java
@@ -151,7 +151,13 @@ public class LobidResources {
 		@Override
 		public QueryBuilder build(final String queryString) {
 			BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
-			for (String q : queryString.split(",")) {
+			String queryParam = queryString;
+			if (!queryString.startsWith("http")
+					&& !queryString.matches("[\\d\\-,]+")) {
+				// multi-val queries only for URIs or GND IDs:
+				queryParam = queryString.replace(',', ' ');
+			}
+			for (String q : queryParam.split(",")) {
 				final MultiMatchQueryBuilder subjectLabelQuery =
 						multiMatchQuery(q, fields().get(0), fields().get(1))
 								.operator(Operator.AND);


### PR DESCRIPTION
Avoids interpreting queries like `Ney, Elisabet` as multi-val.

See https://github.com/hbz/nwbib/issues/151