### PR TITLE
Correct doi in @context

### DIFF
--- a/conf/contexts/lobid-resources.json
+++ b/conf/contexts/lobid-resources.json
@@ -149,10 +149,7 @@
          "@type" : "@id",
          "@id" : "http://id.loc.gov/vocabulary/relators/prf"
       },
-      "doi" : {
-         "@id" : "http://purl.org/ontology/bibo/doi",
-         "@type" : "@id"
-      },
+      "doi" : "http://purl.org/ontology/bibo/doi",
       "hasVersion" : {
          "@type" : "@id",
          "@id" : "http://purl.org/dc/terms/hasVersion"


### PR DESCRIPTION
Obviously, we had some encoding problems that couldn't be seen with the naked exe.