### PR TITLE
Remove link to old API documentation

### DIFF
--- a/app/views/wrapper.scala.html
+++ b/app/views/wrapper.scala.html
@@ -46,8 +46,6 @@
                         <ul class="dropdown-menu">
                           <li><a href="@routes.LobidTeam.team()">Team</a></li>
                           <li><a href="mailto:semweb@@hbz-nrw.de?subject=Feedback%20zu%20lobid.org">Feedback</a></li>
-                          <li role="separator" class="divider"></li>
-                          <li><a href="/api">@Messages("main.navbar.info.v1")</a></li>
                         </ul>
                       </li>
                     </ul>


### PR DESCRIPTION
See https://github.com/lobid/lodmill/issues/802

Deployed to test: https://test.lobid.org / http://weywot2.hbz-nrw.de:7000