### PR TITLE
Set up visualization of team.json data with vis.js network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ typings/
 # gatsby files
 .cache/
 public
+bin
+target
+tmp
 
 # Mac files
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "lts/*"
+before_script:
+  - npm install -g gatsby
+script:
+  - cd gatsby/lobid/
+  - npm install
+  - gatsby build

--- a/gatsby/lobid/gatsby-node.js
+++ b/gatsby/lobid/gatsby-node.js
@@ -7,4 +7,9 @@ exports.createPages = ({ actions }) => {
     path: "/team",
     component: path.resolve(`./src/pages/team-de.js`)
   });
+
+  createPage({
+    path: "/visual",
+    component: path.resolve(`./src/pages/visual.js`)
+  });
 };

--- a/gatsby/lobid/package-lock.json
+++ b/gatsby/lobid/package-lock.json
@@ -15902,6 +15902,16 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vis-data": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.1.tgz",
+      "integrity": "sha512-Z5+caySDqoKL9yxbI3c/CKmUcSvROSZstuvwxbOsUpdxHpxFYEUgxC1EH4lSB1ykEaM54MVMM1UcwB9oNaWFlw=="
+    },
+    "vis-network": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-8.5.4.tgz",
+      "integrity": "sha512-KeYHlTZpbPHS6868MHnMtRXDTmKA0YwQQl/mC5cBiICGH67ilzOqkyWObAMyeo8b8Z/6pTfFJEu9g70EvWqOYA=="
+    },
     "vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",

--- a/gatsby/lobid/package.json
+++ b/gatsby/lobid/package.json
@@ -25,7 +25,9 @@
     "react-dom": "^16.12.0",
     "reactstrap": "^8.4.1",
     "typescript": "^3.6.0-beta",
-    "utf-8-validate": "^5.0.2"
+    "utf-8-validate": "^5.0.2",
+    "vis-data": "^7.1.1",
+    "vis-network": "^8.5.4"
   },
   "devDependencies": {
     "prettier": "^1.19.1"

--- a/gatsby/lobid/src/components/footer.html.js
+++ b/gatsby/lobid/src/components/footer.html.js
@@ -1,0 +1,46 @@
+import React from "react"
+
+import wappenPng from "./images/wappen.png";
+
+export default class Footer extends React.Component {
+    render() {
+      return (
+        <div className="panel panel-default footer">
+          <div className="panel-body">
+            <span className="pull-left">
+              <img src={wappenPng} alt="NRW-Wappen" /> &nbsp; lobid |
+              LOD-Dienste des{" "}
+              <a href="https://www.hbz-nrw.de/produkte/linked-open-data">
+                hbz — Hochschulbibliothekszentrum des Landes NRW
+              </a>
+            </span>
+            <span className="pull-right">
+              <a href="https://www.hbz-nrw.de/impressum">
+                {this.props.companyDetails}
+              </a>
+              {" | "}
+              <a href="https://github.com/hbz/lobid/blob/master/conf/Datenschutzerklaerung_lobid.textile">
+                {this.props.privacy}
+              </a>
+              {" | "}
+              <a
+                href="https://twitter.com/lobidorg"
+                style={{ marginRight: "12px" }}
+              >
+                <i className="fa fa-twitter" aria-hidden="true"></i> Twitter
+              </a>
+              <a
+                href="https://github.com/hbz/lobid"
+                style={{ marginRight: "12px" }}
+              >
+                <i className="fa fa-github" aria-hidden="true"></i> GitHub
+              </a>
+              <a href="http://blog.lobid.org" style={{ marginRight: "12px" }}>
+                <i className="fa fa-pencil" aria-hidden="true"></i> Blog
+              </a>
+            </span>
+          </div>
+        </div>
+      )
+    }
+}

--- a/gatsby/lobid/src/components/header.html.js
+++ b/gatsby/lobid/src/components/header.html.js
@@ -1,0 +1,164 @@
+import React from "react"
+
+import {
+  UncontrolledDropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem
+} from "reactstrap";
+
+import lobidLogoPng from "./images/lobid.png";
+
+export default class Header extends React.Component {
+  render() {
+    return (
+      <div className="navbar navbar-default" role="navigation">
+        <div className="container-fluid" id="header">
+          <div className="navbar-header">
+            <button
+              type="button"
+              className="navbar-toggle collapsed"
+              data-toggle="collapse"
+              data-target="#lobid-nav"
+            >
+              <span className="sr-only">Navigation ein/ausblenden</span>
+              <span className="icon-bar"></span>
+              <span className="icon-bar"></span>
+              <span className="icon-bar"></span>
+            </button>
+            <a className="navbar-brand" href="/">
+              <span>
+                <img id="butterfly" src={lobidLogoPng} alt="lobid-logo" />
+              </span>
+            </a>
+          </div>
+          <div className="navbar-collapse " id="lobid-nav">
+            <ul className="nav navbar-nav">
+              <li>
+                <a href="/resources">resources</a>
+              </li>
+              <li>
+                <a href="/organisations">organisations</a>
+              </li>
+              <li>
+                <a href="/gnd">gnd</a>
+              </li>
+            </ul>
+            <div style={{ marginRight: "-6px" }}>
+              <ul className="nav navbar-nav navbar-right ">
+                <li>
+                  <UncontrolledDropdown>
+                    <DropdownToggle
+                      style={{
+                        padding: "9px",
+                        background: "transparent",
+                        marginTop: "0px",
+                        lineHeight: "30px"
+                      }}
+                    >
+                      {this.props.publications}
+                      <b
+                        className="caret"
+                        style={{
+                          marginLeft: "2px"
+                        }}
+                      ></b>
+                    </DropdownToggle>
+                    <DropdownMenu right>
+                      <DropdownItem
+                        tag="a"
+                        href="http://blog.lobid.org/"
+                        style={{
+                          paddingLeft: "6px",
+                          color: "black",
+                          textDecoration: "none",
+                          lineHeight: "30px"
+                        }}
+                      >
+                        Blog
+                      </DropdownItem>
+                      <DropdownItem divider />
+                      <DropdownItem
+                        as="a"
+                        href="http://slides.lobid.org/"
+                        style={{
+                          paddingLeft: "6px",
+                          color: "black",
+                          textDecoration: "none"
+                        }}
+                      >
+                        Slides
+                      </DropdownItem>
+                    </DropdownMenu>
+                  </UncontrolledDropdown>
+                </li>
+
+                <li>
+                  <a
+                    href={this.props.languageLink}
+                    title={this.props.languageTooltip}
+                  >
+                    <span className="glyphicon glyphicon-globe"></span>
+                    &nbsp;
+                    {this.props.language}
+                  </a>
+                </li>
+
+                <li>
+                  <UncontrolledDropdown>
+                    <DropdownToggle
+                      className="glyphicon glyphicon-info-sign"
+                      style={{
+                        padding: "11px",
+                        background: "transparent",
+                        marginTop: "-3px",
+                        lineHeight: "27px"
+                      }}
+                    >
+                      <b
+                        className="caret"
+                        style={{
+                          marginTop: "-4px",
+                          marginLeft: "2px"
+                        }}
+                      ></b>
+                    </DropdownToggle>
+                    <DropdownMenu right>
+                      <DropdownItem
+                        tag="a"
+                        href={this.props.teamLink}
+                        style={{
+                          paddingLeft: "6px",
+                          color: "black",
+                          textDecoration: "none",
+                          lineHeight: "30px"
+                        }}
+                      >
+                        Team
+                      </DropdownItem>
+                      <DropdownItem divider />
+                      <DropdownItem
+                        as="a"
+                        href={
+                          this.props.contactPointId +
+                          "?subject=Feedback%20zu%20lobid.org"
+                        }
+                        style={{
+                          paddingLeft: "6px",
+                          color: "black",
+                          textDecoration: "none"
+                        }}
+                      >
+                        Feedback
+                      </DropdownItem>
+                    </DropdownMenu>
+                  </UncontrolledDropdown>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>)
+  }
+}
+

--- a/gatsby/lobid/src/components/team.html.js
+++ b/gatsby/lobid/src/components/team.html.js
@@ -1,17 +1,12 @@
 import React from "react";
-import {
-  UncontrolledDropdown,
-  DropdownToggle,
-  DropdownMenu,
-  DropdownItem
-} from "reactstrap";
+import Header from "./header.html";
+import Footer from "./footer.html";
 
 import "./css/lobid.css";
 import "./css/bootstrap.min.css";
 import "./css/font-awesome.min.css";
 
 import hbzLogoPng from "./images/hbz.png";
-import lobidLogoPng from "./images/lobid.png";
 import twitterLogoBluePng from "./images/Twitter_logo_blue.png";
 import mailPng from "./images/mail.png";
 import jsonLdPng from "./images/json-ld.png";
@@ -19,7 +14,6 @@ import feedPng from "./images/feed.png";
 import gitHubMark32pxPng from "./images/GitHub-Mark-32px.png";
 import mailmanJpg from "./images/mailman.jpg";
 import freenodePng from "./images/freenode.png";
-import wappenPng from "./images/wappen.png";
 
 export class Team extends React.Component {
   constructor(props) {
@@ -58,156 +52,18 @@ export class Team extends React.Component {
     );
   };
   render() {
+    console.log('Header', Header);
     return (
       <div className="container">
         <p />
-        <div className="navbar navbar-default" role="navigation">
-          <div className="container-fluid" id="header">
-            <div className="navbar-header">
-              <button
-                type="button"
-                className="navbar-toggle collapsed"
-                data-toggle="collapse"
-                data-target="#lobid-nav"
-              >
-                <span className="sr-only">Navigation ein/ausblenden</span>
-                <span className="icon-bar"></span>
-                <span className="icon-bar"></span>
-                <span className="icon-bar"></span>
-              </button>
-              <a className="navbar-brand" href="/">
-                <span>
-                  <img id="butterfly" src={lobidLogoPng} alt="lobid-logo" />
-                </span>
-              </a>
-            </div>
-            <div className="navbar-collapse " id="lobid-nav">
-              <ul className="nav navbar-nav">
-                <li>
-                  <a href="/resources">resources</a>
-                </li>
-                <li>
-                  <a href="/organisations">organisations</a>
-                </li>
-                <li>
-                  <a href="/gnd">gnd</a>
-                </li>
-              </ul>
-              <div style={{ marginRight: "-6px" }}>
-                <ul className="nav navbar-nav navbar-right ">
-                  <li>
-                    <UncontrolledDropdown>
-                      <DropdownToggle
-                        style={{
-                          padding: "9px",
-                          background: "transparent",
-                          marginTop: "0px",
-                          lineHeight: "30px"
-                        }}
-                      >
-                        {this.props.publications}
-                        <b
-                          className="caret"
-                          style={{
-                            marginLeft: "2px"
-                          }}
-                        ></b>
-                      </DropdownToggle>
-                      <DropdownMenu right>
-                        <DropdownItem
-                          tag="a"
-                          href="http://blog.lobid.org/"
-                          style={{
-                            paddingLeft: "6px",
-                            color: "black",
-                            textDecoration: "none",
-                            lineHeight: "30px"
-                          }}
-                        >
-                          Blog
-                        </DropdownItem>
-                        <DropdownItem divider />
-                        <DropdownItem
-                          as="a"
-                          href="http://slides.lobid.org/"
-                          style={{
-                            paddingLeft: "6px",
-                            color: "black",
-                            textDecoration: "none"
-                          }}
-                        >
-                          Slides
-                        </DropdownItem>
-                      </DropdownMenu>
-                    </UncontrolledDropdown>
-                  </li>
-
-                  <li>
-                    <a
-                      href={this.props.languageLink}
-                      title={this.props.languageTooltip}
-                    >
-                      <span className="glyphicon glyphicon-globe"></span>
-                      &nbsp;
-                      {this.props.language}
-                    </a>
-                  </li>
-
-                  <li>
-                    <UncontrolledDropdown>
-                      <DropdownToggle
-                        className="glyphicon glyphicon-info-sign"
-                        style={{
-                          padding: "11px",
-                          background: "transparent",
-                          marginTop: "-3px",
-                          lineHeight: "27px"
-                        }}
-                      >
-                        <b
-                          className="caret"
-                          style={{
-                            marginTop: "-4px",
-                            marginLeft: "2px"
-                          }}
-                        ></b>
-                      </DropdownToggle>
-                      <DropdownMenu right>
-                        <DropdownItem
-                          tag="a"
-                          href={this.props.teamLink}
-                          style={{
-                            paddingLeft: "6px",
-                            color: "black",
-                            textDecoration: "none",
-                            lineHeight: "30px"
-                          }}
-                        >
-                          Team
-                        </DropdownItem>
-                        <DropdownItem divider />
-                        <DropdownItem
-                          as="a"
-                          href={
-                            this.props.contactPointId +
-                            "?subject=Feedback%20zu%20lobid.org"
-                          }
-                          style={{
-                            paddingLeft: "6px",
-                            color: "black",
-                            textDecoration: "none"
-                          }}
-                        >
-                          Feedback
-                        </DropdownItem>
-                      </DropdownMenu>
-                    </UncontrolledDropdown>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
+        <Header 
+          language={this.props.language} 
+          languageLink={this.props.languageLink}
+          languageTooltip={this.props.languageTooltip}
+          publications={this.props.publications}
+          teamLink={this.props.teamLink}
+          contactPointId={this.props.contactPointId}
+        />
         <div>
           <div className="page-header">
             <h1>
@@ -444,42 +300,7 @@ export class Team extends React.Component {
             {this.props.makesOfferAlternateName3}
           </p>
         </div>
-        <div className="panel panel-default footer">
-          <div className="panel-body">
-            <span className="pull-left">
-              <img src={wappenPng} alt="NRW-Wappen" /> &nbsp; lobid |
-              LOD-Dienste des{" "}
-              <a href="https://www.hbz-nrw.de/produkte/linked-open-data">
-                hbz — Hochschulbibliothekszentrum des Landes NRW
-              </a>
-            </span>
-            <span className="pull-right">
-              <a href="https://www.hbz-nrw.de/impressum">
-                {this.props.companyDetails}
-              </a>
-              {" | "}
-              <a href="https://github.com/hbz/lobid/blob/master/conf/Datenschutzerklaerung_lobid.textile">
-                {this.props.privacy}
-              </a>
-              {" | "}
-              <a
-                href="https://twitter.com/lobidorg"
-                style={{ marginRight: "12px" }}
-              >
-                <i className="fa fa-twitter" aria-hidden="true"></i> Twitter
-              </a>
-              <a
-                href="https://github.com/hbz/lobid"
-                style={{ marginRight: "12px" }}
-              >
-                <i className="fa fa-github" aria-hidden="true"></i> GitHub
-              </a>
-              <a href="http://blog.lobid.org" style={{ marginRight: "12px" }}>
-                <i className="fa fa-pencil" aria-hidden="true"></i> Blog
-              </a>
-            </span>
-          </div>
-        </div>
+        <Footer companyDetails={this.props.companyDetails} privacy={this.props.privacy}/>
       </div>
     );
   }

--- a/gatsby/lobid/src/components/visual.html.js
+++ b/gatsby/lobid/src/components/visual.html.js
@@ -1,0 +1,47 @@
+import React, { Component, createRef } from "react";
+import { DataSet, Network} from 'vis-network/standalone/esm/vis-network';
+
+import "./css/lobid.css";
+
+export class Visual extends Component {
+
+  constructor(props) {
+    super(props);
+    this.props = props;
+    this.state = {
+      infoToggled: false
+    };
+    this.network = {};
+    this.appRef = createRef();
+  }
+
+  componentDidMount() {
+    console.log("Props", this.props)
+
+    var ns = [
+      { id: 'm', label: "Members","shape":"dot","size":"5"},
+      { id: 'o', label: "Offers","shape":"dot","size":"5"}
+    ];
+    this.props.members.forEach((item,index) => { ns.push({ id: "m"+index, label: item.member.name, "shape":"box" }); });
+    this.props.products.forEach((item,index) => { ns.push({ id: "o"+index, label: item.name, "shape":"box" }); });
+    const nodes = new DataSet(ns);
+  
+    var es = [];
+    this.props.members.forEach((item,index) => { es.push({ from: 'm', to: 'm'+index }); });
+    this.props.products.forEach((item,index) => { es.push({ from: 'o', to: 'o'+index }); });
+    const edges = new DataSet(es);
+    
+    const data = {
+      nodes: nodes,
+      edges: edges
+    };
+    const options = {};
+    this.network = new Network(this.appRef.current, data, options);
+  }
+
+  render() {
+    return (
+      <div id="lobid-network" ref={this.appRef} />
+    );
+  }
+}

--- a/gatsby/lobid/src/components/visual.html.js
+++ b/gatsby/lobid/src/components/visual.html.js
@@ -1,7 +1,11 @@
 import React, { Component, createRef } from "react";
 import { DataSet, Network} from 'vis-network/standalone/esm/vis-network';
+import Header from "./header.html";
+import Footer from "./footer.html";
 
 import "./css/lobid.css";
+
+import hbzLogoPng from "./images/hbz.png";
 
 export class Visual extends Component {
 
@@ -41,7 +45,37 @@ export class Visual extends Component {
 
   render() {
     return (
-      <div id="lobid-network" ref={this.appRef} />
+      <div className="container">
+        <p />
+        <Header 
+          language={this.props.language} 
+          languageLink={this.props.languageLink}
+          languageTooltip={this.props.languageTooltip}
+          publications={this.props.publications}
+          teamLink={this.props.teamLink}
+          contactPointId={this.props.contactPointId}
+        />
+        <div>
+          <div className="page-header">
+            <h1>
+              <img
+                className="media-object nrw-logo pull-right"
+                src={hbzLogoPng}
+                alt="hbz logo"
+              />
+              lobid <small>&mdash; {this.props.subtitle}</small>
+            </h1>
+          </div>
+          <p>
+            <i>
+              Dies ist eine experimentelle Visualisierung der Daten aus <a href="/team.json">/team.json</a>,
+              die auch zur Darstellung von <a href="/team">/team</a> verwendet werden.
+            </i>
+          </p>
+          <div id="lobid-network" ref={this.appRef} />
+        </div>
+        <Footer companyDetails={this.props.companyDetails} privacy={this.props.privacy}/>
+      </div>
     );
   }
 }

--- a/gatsby/lobid/src/pages/visual.js
+++ b/gatsby/lobid/src/pages/visual.js
@@ -6,6 +6,15 @@ export default ({ data }) => (
   <Visual
     members = {data.dataJson.member}
     products = {data.dataJson.makesOffer}
+    language="English"
+    languageTooltip="Switch language to English"
+    languageLink="/visual"
+    teamLink="/team-de"
+    publications="Publikationen"
+    contactPointId={data.dataJson.contactPoint[0].id}
+    companyDetails="Impressum"
+    privacy="Datenschutz"
+    subtitle={data.dataJson.makesOffer[0].alternateName.de}
   />
 );
 
@@ -28,6 +37,12 @@ export const query = graphql`
         roleName {
           de
         }
+      }
+      contactPoint {
+        contactType {
+          de
+        }
+        id
       }
     }
   }

--- a/gatsby/lobid/src/pages/visual.js
+++ b/gatsby/lobid/src/pages/visual.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { graphql } from "gatsby";
+import { Visual } from "../components/visual.html";
+
+export default ({ data }) => (
+  <Visual
+    members = {data.dataJson.member}
+    products = {data.dataJson.makesOffer}
+  />
+);
+
+export const query = graphql`
+  query {
+    dataJson {
+      makesOffer {
+        alternateName {
+          de
+        }
+        id
+        name
+      }
+      member {
+        member {
+          id
+          image
+          name
+        }
+        roleName {
+          de
+        }
+      }
+    }
+  }
+`;

--- a/gatsby/lobid/static/stylesheets/lobid.css
+++ b/gatsby/lobid/static/stylesheets/lobid.css
@@ -1,7 +1,6 @@
 #lobid-network {
 	width: 900px;
-	height: 600px;
-	border: 1px solid lightgray;
+	height: 500px;
 	margin: 20px;
 }
 

--- a/gatsby/lobid/static/stylesheets/lobid.css
+++ b/gatsby/lobid/static/stylesheets/lobid.css
@@ -1,3 +1,10 @@
+#lobid-network {
+	width: 900px;
+	height: 600px;
+	border: 1px solid lightgray;
+	margin: 20px;
+}
+
 #header {
 	width: 100%;
 	background-image: url('https://lobid.org/images/clouds.jpg');


### PR DESCRIPTION
See https://github.com/hbz/lobid/issues/427

Should be mergeable without side effects, the new `/visual` path is not linked anywhere. It might make sense to continue some work here as things are discussed in #427, so leaving unassigned for now, but before changing other things in master, we should merge this to avoid conflicts.