### PR TITLE
Migrate continuous integration from travis to github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push
+env:
+  NODE_VERSION: '14.15.3'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - run: |
+        npm install -g gatsby
+        cd gatsby/lobid/
+        npm ci
+        gatsby build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - "lts/*"
-before_script:
-  - npm install -g gatsby
-script:
-  - cd gatsby/lobid/
-  - npm install
-  - gatsby build

--- a/README.textile
+++ b/README.textile
@@ -1,8 +1,10 @@
 h1. Lobid
 
+"!https://github.com/hbz/lobid/workflows/Build/badge.svg?branch=master!":https://github.com/hbz/lobid/actions?query=workflow%3ABuild
+
 Linking Open Bibliographic Data.
 
-This is only the repo of the landing page of https://lobid.org/ and some sub-sites created with _gatsby_.
+This is only the repo of the landing page of https://lobid.org/ and some sub-sites created with _gatsby_ (see "Lobid's gatsby starter":https://github.com/hbz/lobid/tree/master/gatsby/lobid ).
 
 For the repos with the software implementations, see:
 


### PR DESCRIPTION
- add github-actions' build.yml
- remove travis build
- update README badge
- link to "Lobid's gatsby starter" in the README

See #433