### PR TITLE
Add descriptions and StoeberSpecs & SkoHub projects

### DIFF
--- a/examples/project/valid/alma2lobid.json
+++ b/examples/project/valid/alma2lobid.json
@@ -10,12 +10,17 @@
   },
   "description": {
     "en": "Switch lobid-resources ETL and indexing from Aleph to Alma Marc21 XML",
-    "de": "Umstieg von Aleph- auf Alma-MARC21-Daten bei Transformation und Indexierung für lobid-resources"
+    "de": "Der schrittweise Umstieg der hbz-Verbundbibliotheken auf das Bibliotheksmanagementsystem Alma im Rahmen des GO:AL-Projekts (GOAL) bringt auch für die Gruppe Offene Infrastruktur dauerhaft Aufgaben mit sich: lobid indexiert unter anderem die Verbunddaten des hbz, die nun schrittweise nach Alma wandern. Demenstprechend müssen sämtliche Prozesse zum Extrahieren, Transformieren und Laden (ETL) der Verbunddaten angepasst werden, damit sie (auch) auf Basis von Alma-Daten funktionieren."
   },
   "url": "https://github.com/hbz/lobid-resources/milestone/1",
   "enhances": [
     {
       "id": "https://lobid.org"
+    }
+  ],
+  "isBasedOn": [
+    {
+      "id": "https://metafacture.org"
     }
   ]
 }

--- a/examples/project/valid/lrmi-profile.json
+++ b/examples/project/valid/lrmi-profile.json
@@ -10,7 +10,11 @@
   },
   "description": {
     "en": "A schema.org/LRMI-based profile for describing OER developed and published as JSON Schema",
-    "de": "Ein schema.org-/LRMI-basiertes Metadatenprofil für die Beschreibung von OER mit Fokus auf den deutschsprachigen Raum, zunächst entwickelt als JSON Schema"
+    "de": "In diesem Projekt wird die erste offizielle Version eines Metadatenprofils für die web-konforme Publikation von Metadaten für Lehr- und Lernressourcen im deutschsprachigen Raum entwickelt. Es basiert auf dem schema.org-Vokabular mit seinen LRMI_Erweiterungen (Learning Resource Metadata Initiative) und fokussiert auf die Publikation der Metadaten als JSON-LD.\n\nDas Profil ist Basis für das Index-Schema im OERSI-Projekt (OEI) und soll als Vorgabe dienen für die Vergabe von Metadaten für OERs, die mit Fördergeldern des Landes NRW erstellt werden.\n\nFür die Validierung von Metadaten im Hinblick auf ihre Konformität zum Profil wird ein JSON Schema gepflegt."
   },
-  "url": "https://github.com/dini-ag-kim/lrmi-profile"
+  "isBasedOn": [
+    {
+      "id": "https://github.com/dini-ag-kim/oer-stoeberspecs"
+    }
+  ]
 }

--- a/examples/project/valid/metafacture-fix.json
+++ b/examples/project/valid/metafacture-fix.json
@@ -10,7 +10,7 @@
   },
   "description": {
     "en": "Implementation of the Fix language for Metafacture as an alternative to configuring data transformations with Metamorph",
-    "de": "Das Projekt entwickelt und implementiert FIX als Metafacture Sprache. Diese soll als Alternative zu Metamorph für Datentransformation eingesetzt werden."
+    "de": "Ziel des Projekts ist die Erleichterung der Metafacture-Konfiguration und damit die Erweiterung der Zielgruppe um Bibliothekar*innen und andere Metadatenfachleute, die keinen Programmierhintergrund haben.\n\nDies geschieht durch die Implementierung der Fix-DSL für die Konfiguration von Metadatenmappings als Alternative zum XML-basierten Metamorph. Zunächst wird die Erweiterung zur produktiven Nutzung im OERSI-Kontext und anderen neu zu erstellenden ETL-Prozessen entwickelt und dann auf die komplexeren Prozesse – etwa im lobid-Kontext – ausgeweitet.\n\nIn einem nächsten Schritt – voraussichtlich 2022 – wird an einer Standardisierung der Fix-Sprache gearbeitet mit dem Ziel, Kompatibilität zwischen Metafacture und Catmandu zu erreichen."
   },
   "url": "https://github.com/metafacture/metafacture-fix",
   "enhances": [

--- a/examples/project/valid/metafacture-playground.json
+++ b/examples/project/valid/metafacture-playground.json
@@ -10,12 +10,17 @@
   },
   "description": {
     "en": "This projects aims to provide a web application to play around with Metafactures languages Fix and Flux.",
-    "de": "Dieses Projekt entwickelt eine Web-Applikation, mit der man interaktiv die Metafacture-Sprachen Fix und Flux austesten kann."
+    "de": "Der Metafacture Playground ist eine browserbasierte Umgebung, um an der Konfiguration von ETL-Prozessen mittels Metafacture zu arbeiten. Der Playground nutzt die [Metafacture-Fix-Erweiterung (MFF)](https://github.com/metafacture/metafacture-fix). Kurzfristig soll der Playground zum Teilen von ETL-Konfigurationen via URL und für aktive Arbeit in metafacture-Workshops Verwendung finden.\n\nMittelfristiges Ziel ist der Aufbau einer Plattform zum Teilen von ETL-Konfigurationen, um das Auffinden bestehender Lösungen und deren Nachnutzung zu erleichtern und damit Parallelarbeiten zu vermeiden."
   },
   "url": "https://github.com/metafacture/metafacture-playground",
   "enhances": [
     {
       "id": "https://metafacture.org"
+    }
+  ],
+  "isBasedOn": [
+    {
+      "id": "https://github.com/metafacture/metafacture-fix"
     }
   ]
 }

--- a/examples/project/valid/oersi.json
+++ b/examples/project/valid/oersi.json
@@ -16,7 +16,12 @@
     "en": "Common project by TIB Hannover and hbz to create an open search index for educational resources"
   },
   "url": "https://oersi.de",
-  "isBasedOn": {
-    "id": "https://metafacture.org"
-  }
+  "isBasedOn": [
+    {
+      "id": "https://metafacture.org"
+    },
+    {
+      "id": "https://github.com/dini-ag-kim/lrmi-profile"
+    }
+  ]
 }

--- a/examples/project/valid/rpb.json
+++ b/examples/project/valid/rpb.json
@@ -10,7 +10,22 @@
   },
   "description": {
     "en": "Migrating the RPB from Allegro to a new cataloging and web presentation environment",
-    "de": "Migration der Rheinland-Pfälzischen Bibliographie (RPB) von Allegro in eine neue Erfassungs- und Präsentationsumgebung. Nutzen von Erfahrungen und Technologien aus NWbib und SkoHub."
+    "de": "Das Landesbibliothekszentrum Rheinland-Pfalz hat das hbz beauftragt, die Rheinland-Pfälzische Bibliographie (RPB) von Allegro in eine neues System zu migrieren, das Erfassung und Präsentation der Bibliographie im Web abdeckt. Auf Basis der Erfahrungen mit der Nordrhein-Westfälischen Bibliographie (NWBib) und mit einer Erweiterung der SkoHub-Software um ein weiteres Modul zur Erfassung, Speicherung und Pflege von Linked Data wird das Projekt umgesetzt. Mit Metafacture werden zunächst die Allegro-Daten nach Linked Date überführt und indexiert und parallel an einer Erfassungs -und Speicherschicht gearbeitet."
   },
-  "url": "https://github.com/hbz/rpb"
+  "startDate": "2021-04-01",
+  "endDate": "2022-03-31",
+  "isBasedOn": [
+    {
+      "id": "https://metafacture.org"
+    },
+    {
+      "id": "https://skohub.io"
+    },
+    {
+      "id": "https://nwbib.de"
+    },
+    {
+      "id": "https://lobid.org"
+    }
+  ]
 }

--- a/examples/project/valid/skohub-project.json
+++ b/examples/project/valid/skohub-project.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://schema.org/",
+  "id": "https://github.com/skohub-io",
+  "type": [
+    "Project"
+  ],
+  "name": {
+    "de": "SkoHub",
+    "en": "SkoHub"
+  },
+  "description": {
+    "de": "Kontrollierte Vokabulare, Normdaten und andere Wissensorganisationssysteme sind seit langem ein zentraler Bestandteil der Wissensorganisation. Sie werden häufig von mehreren, unterschiedlichen Institutionen bei der Erschließung von Ressourcen verwendet und verbinden somit indirekt Ressourcen zum gleichen Thema. Damit alle Einträge zu einem Thema tatsächlich gefunden werden können, müssen meist die einzelnen Kataloge bzw. Datenbanken abgefragt oder übergreifende Suchindizes aufgebaut werden. Dieser Ansatz bringt viele Schwierigkeiten mit sich.\n\nDer strategische Ansatz von SkoHub verlagert die Sach- und Inhaltserschließung konsequent ins Web, um darauf neue, leistungsfähige Discovery-Werkzeuge aufzubauen. Innovatives Merkmal der SkoHub-Infrastruktur ist die Nutzung von  bilden Wissensorganisationssystemen, eine als themenorientierte Schnittstelle zwischen Publizierenden und Wissenssuchenden. Damit wird es möglich, bestimmten Themen (im Sinne von Einträgen einer Klassifikation, eines Thesaurus etc.) zu folgen und Push-Benachrichtigungen zu bekommen, sobald irgendjemand eine Ressource mit dem entsprechenden Thema inhaltlich erschlossen hat.\n\nDas SkoHub-Projekt ist entstanden als begleitendes Projekt im Rahmen des Vorprojekt Content Marktplatz NRW und wird gefördert vom Ministerium für Kultur und Wissenschaft. Im Kontext des NRW Landesportals kann SkoHub zur Erschließung von dezentral im Web publizierten Inhalten mit hochqualitativen Metadaten benutzt werden. Für die technische Umsetzung wurde die graphthinking GmbH beauftragt.",
+    "en": "SkoHub supports a novel approach for finding content on the web. The general idea is to extend the scope of Knowledge Organization Systems (KOS) to also act as communication hubs for publishers and information seekers. In effect, SkoHub allows to follow specific subjects in order to be notified when new content about that subject is published.\n\nThe approach is realized by putting Knowledge Organization Systems online according to the SKOS standard. Additionally, they are exposed using the (social) networking protocols ActivityPub & Linked Data Notifications. This effectively turns the published vocabularies into hubs that provide structured metadata about and links to web content in real time.\n\nThe project to create a production-ready version of SkoHub has been carried out by the North-Rhine Westphalian Library Service Centre (hbz) in cooperation with graphthinking GmbH with four deliverables. The core is the back end infrastructure for publishing vocabularies on the web (Skohub Vocabs) and for receiving and pushing notifications (SkoHub PubSub). Additionally, we provide an editor to describe web resources according to a common metadata schema and to send notifications (SkoHub Editor). The editor can also be used as a browser plugin for Firefox and Chrome (SkoHub Extension)."
+  },
+  "startDate": "2019-03-06",
+  "endDate": "2020-03-31",
+  "result": [
+    {
+      "id": "https://skohub.io"
+    }
+  ]
+}

--- a/examples/project/valid/stoeberspecs.json
+++ b/examples/project/valid/stoeberspecs.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://schema.org/",
+  "id": "https://github.com/dini-ag-kim/oer-stoeberspecs",
+  "type": [
+    "Project"
+  ],
+  "name": {
+    "de": "StöberSpecs",
+    "en": "StöberSpecs"
+  },
+  "description": {
+    "de": "Im Rahmen des Projektes StöberSpecs entstehen Werkzeuge und Prozesse für die gemeinsame Entwicklung von Spezifikationen (engl. Kurzfassung „Specs“) von Metadatenstandards, die das „Aufstöbern“ von Open Educational Resources (OER) erleichtern sollen. Das Projekt wird gefördert durch das Ministerium für Kultur und Wissenschaft und durchgeführt in Zusammenarbeit mit Open Culture Consulting.\n\nSeinen Ausgangspunkt hatte das Projekt in der OER-Repo-AG der Bundesländer, die ihren Auftrag aus der AG \"Digitalisierung im Hochschulbereich\" des Hochschulausschusses der KMK hat. Dort wurde 2019 ein erster OER-Metadatenstandard entwickelt, allerdings in einem eher geschlossenen Verfahren. Als öffentliches Forum zur gemeinsamen fortdauernden, transparenten und nachhaltigen Entwicklung und Pflege von Metadatenstandards wurde die seit 2013 bestehende OER-Metadatengruppe der DINI AG KIM gewählt, die 2017 mit der Jointly-AG-Metadaten fusionierte.\n\nFür die Standardisierung von kontrollierten Vokabularen setzt das Projekt auf das SKOS-Datenmodell (Simple Knowledge Organization Systems) und liefert als ein Ergebnis eine [deutschsprachige SKOS-Einführung](https://dini-ag-kim.github.io/skos-einfuehrung/). Zur Publikation und Pflege von SKOS-Vokabularen greift das Projekt auf die entsprechenden SkoHub-Entwicklungen zurück ([SkoHub Vocabs](https://github.com/skohub-io/skohub-vocabs)).",
+    "en": "Project to develop tools and processes for the standardization of metadata profiles and controlled vocabularies within KI;."
+  },
+  "startDate": "2019-11-01",
+  "endDate": "2020-01-31",
+  "isBasedOn": [
+    {
+      "id": "https://skohub.io"
+    }
+  ]
+}

--- a/schemas/project.json
+++ b/schemas/project.json
@@ -27,6 +27,9 @@
     "image": {
       "$ref": "resource:/image.json"
     },
+    "isBasedOn": {
+      "$ref": "resource:/isBasedOn.json"
+    },
     "startDate": {
       "$ref": "resource:/startDate.json"
     },
@@ -35,6 +38,9 @@
     },
     "enhances": {
       "$ref": "resource:/enhances.json"
+    },
+    "result": {
+      "$ref": "resource:/result.json"
     },
     "membership": {
       "$ref": "resource:/membership.json"

--- a/schemas/result.json
+++ b/schemas/result.json
@@ -1,0 +1,18 @@
+{
+  "$id": "resource:/result.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "result",
+  "description": "Entities (mostly products) that result from a project",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "resource:/id.json"
+      }
+    },
+    "required": [
+      "id"
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds:

- two more projects with more relations (including the new `result` relation)
- longer description texts from the AEP, trying out markdown syntax
- update to the project.json schema (adding `isBasedOn` relation that was missing