### PR TITLE
Add recent publications

### DIFF
--- a/gatsby/lobid/static/publication/2021-sammelband.json
+++ b/gatsby/lobid/static/publication/2021-sammelband.json
@@ -1,0 +1,45 @@
+{
+  "@context": "https://schema.org",
+  "type": [
+    "Article"
+  ],
+  "name": {
+    "de": "Ein Protokoll für den Datenabgleich im Web am Beispiel von OpenRefine und der Gemeinsamen Normdatei (GND)"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/fs#!",
+      "type": "Person",
+      "name": "Fabian Steeg"
+    },
+    {
+      "id": "http://lobid.org/team/ap#!",
+      "type": "Person",
+      "name": "Adrian Pohl"
+    }
+  ],
+  "description": {
+    "de": "Beitrag im Sammelband 'Qualität in der Inhaltserschließung'"
+  },
+  "keywords": [
+    "GND",
+    "Integrated Authority File",
+    "Web APIs",
+    "OpenRefine"
+  ],
+  "about": [
+    {
+      "id": "https://lobid.org/product/lobid"
+    }
+  ],
+  "id": "https://doi.org/10.1515/9783110691597-013",
+  "datePublished": "2021",
+  "inLanguage": [
+    "de"
+  ],
+  "audience": [
+    "web developers",
+    "librarians"
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2022-01-metafacture-hbz.json
+++ b/gatsby/lobid/static/publication/2022-01-metafacture-hbz.json
@@ -1,0 +1,50 @@
+{
+    "@context": "https://schema.org",
+    "type": [
+        "PresentationDigitalDocument"
+    ],
+    "id": "https://slides.lobid.org/2022-01-metafacture-hbz/",
+    "name": {
+        "de": "Metafacture – Datentransformation im hbz"
+    },
+    "creator": [
+        {
+            "id": "http://lobid.org/team/ap#!",
+            "type": "Person",
+            "name": "Adrian Pohl"
+        },
+        {
+            "id": "http://lobid.org/team/fs#!",
+            "type": "Person",
+            "name": "Fabian Steeg"
+        }
+    ],
+    "description": {
+        "de": "Präsentation auf einer hbz-internen Metafacture-Infoveranstaltung"
+    },
+    "keywords": [
+        "Metafacture"
+    ],
+    "about": [
+        {
+            "id": "https://lobid.org/product/metafacture"
+        },
+        {
+            "id": "https://lobid.org/project/metafacture-fix"
+        },
+        {
+            "id": "https://lobid.org/project/metafacture-playground"
+        }
+    ],
+    "datePublished": "2022-01-20",
+    "inLanguage": [
+        "de"
+    ],
+    "isBasedOn": "https://slides.lobid.org/metafacture-2020/",
+    "audience": [
+        "management",
+        "librarians",
+        "developers"
+    ],
+    "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2022-05-02-kim-ws.json
+++ b/gatsby/lobid/static/publication/2022-05-02-kim-ws.json
@@ -1,0 +1,50 @@
+{
+    "@context": "https://schema.org",
+    "type": [
+        "PresentationDigitalDocument"
+    ],
+    "id": "https://slides.lobid.org/2022-05-02-kim-ws/",
+    "name": {
+        "de": "Datentransformation mit Metafacture – Aktuelle Entwicklungen"
+    },
+    "creator": [
+    {
+        "id": "http://lobid.org/team/ap#!",
+        "type": "Person",
+        "name": "Adrian Pohl"
+    },
+    {
+        "id": "http://lobid.org/team/fs#!",
+        "type": "Person",
+        "name": "Fabian Steeg"
+    }
+    ],
+    "description": {
+        "de": "Präsentation beim KIM Workshop 2022"
+    },
+    "keywords": [
+        "Metafacture"
+    ],
+    "about": [
+        {
+            "id": "https://lobid.org/product/metafacture"
+        },
+        {
+            "id": "https://lobid.org/project/metafacture-fix"
+        },
+        {
+            "id": "https://lobid.org/project/metafacture-playground"
+        }
+    ],
+    "datePublished": "2022-05-02",
+    "inLanguage": [
+        "de"
+    ],
+    "isBasedOn": "https://slides.lobid.org/2022-01-metafacture-hbz/",
+    "audience": [
+        "management",
+        "librarians",
+        "developers"
+    ],
+    "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2022-05-06-lod-dipf.json
+++ b/gatsby/lobid/static/publication/2022-05-06-lod-dipf.json
@@ -3,7 +3,7 @@
     "type": [
         "PresentationDigitalDocument"
     ],
-    "id": "https://slides.lobid.org/2021-weimar/",
+    "id": "https://slides.lobid.org/2022-05-06-lod-dipf/",
     "name": {
         "de": "Linked Open Data – Eine Einführung"
     },

--- a/gatsby/lobid/static/publication/2022-05-06-lod-dipf.json
+++ b/gatsby/lobid/static/publication/2022-05-06-lod-dipf.json
@@ -1,0 +1,43 @@
+{
+    "@context": "https://schema.org",
+    "type": [
+        "PresentationDigitalDocument"
+    ],
+    "id": "https://slides.lobid.org/2021-weimar/",
+    "name": {
+        "de": "Linked Open Data – Eine Einführung"
+    },
+    "creator": [
+        {
+            "id": "http://lobid.org/team/ap#!",
+            "type": "Person",
+            "name": "Adrian Pohl"
+        }
+    ],
+    "description": {
+        "de": "Präsentation beim DIPF am 6.5.2022"
+    },
+    "keywords": [
+        "Linked Open Data",
+        "Linked Open Usable Data"
+    ],
+    "about": [
+        {
+            "id": "https://lobid.org/product/lobid"
+        },
+        {
+            "id": "https://lobid.org/product/metafacture"
+        },
+        {
+            "id": "https://lobid.org/product/skohub"
+        }
+    ],
+    "datePublished": "2022-06-05",
+    "inLanguage": [
+        "de"
+    ],
+    "isBasedOn": [
+        "https://malis21.acka47.net/slides/2022-01-28.html"
+    ],
+    "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2022-05-metafacture-workshop.json
+++ b/gatsby/lobid/static/publication/2022-05-metafacture-workshop.json
@@ -1,0 +1,54 @@
+{
+    "@context": "https://schema.org",
+    "type": [
+        "PresentationDigitalDocument"
+    ],
+    "id": "https://slides.lobid.org/2022-05-metafacture-workshop/",
+    "name": {
+        "de": "Metadatenworkflows mit Metafacture erstellen und verwalten"
+    },
+    "creator": [
+    {
+        "id": "http://lobid.org/team/fs#!",
+        "type": "Person",
+        "name": "Fabian Steeg"
+    },
+    {
+        "id": "http://lobid.org/team/tb#!",
+        "type": "Person",
+        "name": "Tobias Bülte"
+    }
+    ],
+    "description": {
+        "de": "Hands-on Lab beim Bibliothekskongress 2022 in Leipzig"
+    },
+    "keywords": [
+        "Metafacture"
+    ],
+    "about": [
+        {
+            "id": "https://lobid.org/product/metafacture"
+        },
+        {
+            "id": "https://lobid.org/project/metafacture-fix"
+        },
+        {
+            "id": "https://lobid.org/project/metafacture-playground"
+        }
+    ],
+    "datePublished": "2022-05-31",
+    "inLanguage": [
+        "de"
+    ],
+    "isBasedOn": [
+        "https://slides.lobid.org/2022-05-02-kim-ws/",
+        "https://slides.lobid.org/2022-01-metafacture-hbz/",
+        "https://slides.lobid.org/metafacture-2020/"
+    ],
+    "audience": [
+        "management",
+        "librarians",
+        "developers"
+    ],
+    "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2022-abitech.json
+++ b/gatsby/lobid/static/publication/2022-abitech.json
@@ -1,0 +1,42 @@
+{
+  "@context": "https://schema.org",
+  "type": [
+    "Article"
+  ],
+  "name": {
+    "de": "Wie kann ich Daten aus einem Digitalisierungsprojekt mit Normdaten anreichern?"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/fs#!",
+      "type": "Person",
+      "name": "Fabian Steeg"
+    }
+  ],
+  "description": {
+    "de": "ABI-Technik-Frage"
+  },
+  "keywords": [
+    "GND",
+    "Integrated Authority File",
+    "Web APIs",
+    "JSON-LD",
+    "Linked Open Data",
+    "OpenRefine",
+    "lobid"
+  ],
+  "about": [
+    {
+      "id": "https://lobid.org/product/lobid"
+    }
+  ],
+  "id": "https://doi.org/10.1515/abitech-2022-0012",
+  "datePublished": "2022",
+  "inLanguage": [
+    "de"
+  ],
+  "audience": [
+    "librarians"
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2022-halle-reconciliation.json
+++ b/gatsby/lobid/static/publication/2022-halle-reconciliation.json
@@ -1,0 +1,44 @@
+{
+    "@context": "https://schema.org",
+    "type": [
+        "PresentationDigitalDocument"
+    ],
+    "id": "https://slides.lobid.org/2022-halle-reconcile",
+    "name": {
+        "de": "Integration externer Normdatenquellen für Abgleich und Anreicherung lokaler Daten in OpenRefine"
+    },
+    "creator": [
+        {
+            "id": "http://lobid.org/team/fs#!",
+            "type": "Person",
+            "name": "Fabian Steeg"
+        },
+        {
+            "id": "http://lobid.org/team/ap#!",
+            "type": "Person",
+            "name": "Adrian Pohl"
+        }
+    ],
+    "about": [
+        {
+            "id": "https://lobid.org/product/lobid"
+        }
+    ],
+    "keywords": [
+        "openrefine",
+        "reconciliation"
+    ],
+    "url": "https://slides.lobid.org/2022-halle-reconcile/",
+    "datePublished": "2022-03-28",
+    "inLanguage": [
+        "de"
+    ],
+    "audience": [
+        "librarians",
+        "developers"
+    ],
+    "isBasedOn": [
+        "https://slides.lobid.org/2021-kim-reconcile/"
+    ],
+    "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2022-zbiw.json
+++ b/gatsby/lobid/static/publication/2022-zbiw.json
@@ -1,0 +1,50 @@
+{
+    "@context": "https://schema.org",
+    "type": [
+        "PresentationDigitalDocument"
+    ],
+    "name": {
+        "de": "Offene Infrastruktur für bibliothekarische Daten: Linked Open Data, JSON & OpenRefine in der Praxis"
+    },
+    "creator": [
+        {
+            "id": "http://lobid.org/team/ap#!",
+            "type": "Person",
+            "name": "Adrian Pohl"
+        },
+        {
+            "id": "http://lobid.org/team/fs#!",
+            "type": "Person",
+            "name": "Fabian Steeg"
+        }
+    ],
+    "keywords": [
+        "lobid",
+        "JSON-LD",
+        "Linked Open Data",
+        "libraries"
+    ],
+    "id": "https://slides.lobid.org/2022-zbiw/",
+    "about": [
+        {
+            "id": "https://lobid.org/product/lobid"
+        }
+    ],
+    "datePublished": "2022-02-10",
+    "inLanguage": [
+        "de"
+    ],
+    "audience": [
+        "librarians",
+        "developers"
+    ],
+    "isBasedOn": [
+        {
+            "id": "https://slides.lobid.org/zbiw-2020/"
+        },
+        {
+            "id": "https://slides.lobid.org/2021-kim-reconcile"
+        }
+    ],
+    "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/infoprax-2019.json
+++ b/gatsby/lobid/static/publication/infoprax-2019.json
@@ -4,7 +4,7 @@
     "Article"
   ],
   "name": {
-    "de": "lobid-organisations: Ein umfassender Index deutscher Informationseinrichtungen"
+    "de": "lobid-gnd – Eine Schnittstelle zur Gemeinsamen Normdatei für Mensch und Maschine"
   },
   "creator": [
     {


### PR DESCRIPTION
Update publications for http://lobid.org/team.

Slides data is copy-paste from the (slightly tweaked, see https://github.com/hbz/slides/commit/6182ffc0f42c68b869ddd35f4e3a5845a981ffe6) embedded JSON-LD in http://slides.lobid.org. This could probably be automated pretty easily with Metafacture in the future.

Currently not deployed to stage, I think due to the server move we have no current Gatsby and separate stage setup on `emphytos` as described in the [README](https://github.com/hbz/lobid/tree/master/gatsby/lobid#readme). Is that correct, and should I set that up on `emphytos`, @dr0i?