### PR TITLE
Use "jsonId" instead of "id" (#501)

### DIFF
--- a/gatsby/lobid/src/components/member.html.js
+++ b/gatsby/lobid/src/components/member.html.js
@@ -48,7 +48,7 @@ export class Member extends React.Component {
 
           <div className="row">
             <div className="col-md-9">
-              <p className="lead">{this.props.member.name.label}<small><a title="Beschreibung als JSON-LD anzeigen" href={'/team/' + this.props.member.id.slice(this.props.member.id.lastIndexOf("/") + 1, this.props.member.id.lastIndexOf("!#") - 1) + '.json'}><img className='json-ld-icon' src={jsonLdPng} alt="JSON-LD" /></a></small></p>
+              <p className="lead">{this.props.member.name.label}<small><a title="Beschreibung als JSON-LD anzeigen" href={'/team/' + this.props.member.jsonId.slice(this.props.member.jsonId.lastIndexOf("/") + 1, this.props.member.jsonId.lastIndexOf("!#") - 1) + '.json'}><img className='json-ld-icon' src={jsonLdPng} alt="JSON-LD" /></a></small></p>
               <table className="table table-striped table-condensed">
                 <thead>
                   <tr><th width="20%" /><th width="80%" /></tr>

--- a/gatsby/lobid/src/templates/member.js
+++ b/gatsby/lobid/src/templates/member.js
@@ -41,6 +41,7 @@ export const query = graphql`
       edges {
         node {
           childTeamJson {
+            jsonId
             name {
               label: de
             }


### PR DESCRIPTION
The "id" is used internally by gatsby and is not the value of the json field "id" but rather an internally generated id. So the value of your json's "id" is stored in "jsonId". Use this field to access the json's "id".

See https://www.gatsbyjs.com/plugins/gatsby-transformer-json/#id-and-jsonid-key.

Resolves #501.