### PR TITLE
Fix ids in project, publication and product queries

### DIFF
--- a/gatsby/lobid/src/templates/member.js
+++ b/gatsby/lobid/src/templates/member.js
@@ -8,15 +8,15 @@ export default function MemberPage({ data, location, pageContext }) {
     member={member}
     products={data.allProductJson.edges
       .map(edge => edge.node)
-      .filter(p => p.membership.find(m => m.member.jsonId === member.jsonId))
+      .filter(p => p.membership.find(m => m.member.id === member.jsonId))
     }
     projects={data.allProjectJson.edges
       .map(edge => edge.node)
-      .filter(p => !p.endDate && p.membership.find(m => m.member.jsonId === member.jsonId))
+      .filter(p => !p.endDate && p.membership.find(m => m.member.id === member.jsonId))
     }
     pubs={data.allPublicationJson.edges
       .map(edge => edge.node)
-      .filter(p => p.creator.find(c => c.jsonId === member.jsonId))
+      .filter(p => p.creator.find(c => c.id === member.jsonId))
       .sort((a, b) => b.datePublished.localeCompare(a.datePublished))
     }
     contactName="Kontakt"


### PR DESCRIPTION
With #503 Gatsby did not find any more the correct id for the publications and so on. Because the gatsby-transformer-plugin changes `id` to jsonId`, but only on the top level of nodes things are a bit messed up. Unfortunatley it does this automatically, and it is not configurable (https://www.gatsbyjs.com/plugins/gatsby-transformer-json/#id-and-jsonid-key, otherwise we could for example always use jsonId).