### PR TITLE
Add german as context, #510

### DIFF
--- a/gatsby/lobid/gatsby-node.js
+++ b/gatsby/lobid/gatsby-node.js
@@ -116,7 +116,8 @@ exports.createPages = async ({ graphql, actions }) => {
       path: node.frontmatter.slug,
       component: path.resolve(`./src/templates/markdown.js`),
       context: {
-        slug: node.frontmatter.slug
+        slug: node.frontmatter.slug,
+        lang: "de"
       },
     })
   })


### PR DESCRIPTION
Pages created from markdown should be in the german context for now as there are only german versions available.