### PR TITLE
Fix slug in markdown file

### DIFF
--- a/gatsby/lobid/static/pages/warranty.md
+++ b/gatsby/lobid/static/pages/warranty.md
@@ -1,5 +1,5 @@
 ---
-slug: warranty
+slug: "/warranty"
 title: Informationen zur Gewährleistung
 ---
 


### PR DESCRIPTION
the language context seems to be not working properly when slug is in wrong format