### PR TITLE
Fix imagesproxy for image paths without query parameter

### DIFF
--- a/gatsby/lobid/static/imagesproxy.php
+++ b/gatsby/lobid/static/imagesproxy.php
@@ -7,11 +7,13 @@
         $positionOfColon = strpos($url,"%");
         $url= substr_replace($url,":",$positionOfColon,3);
         // restore the query Parameter
-        $positionOfQueryParameter = strrpos($url,"%3F");
-        $url= substr_replace($url,"?",$positionOfQueryParameter,3);
-        // restore the
-        $positionOfEqual = strrpos($url,"%3D", $positionOfQueryParameter);
-        $url= substr_replace($url,"=",$positionOfEqual,3);
+	$positionOfQueryParameter = strrpos($url,"%3F");
+	if ($positionOfQueryParameter !== false) {
+        	$url= substr_replace($url,"?",$positionOfQueryParameter,3);
+        	// restore the
+        	$positionOfEqual = strrpos($url,"%3D", $positionOfQueryParameter);
+        	$url= substr_replace($url,"=",$positionOfEqual,3);
+	}
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);


### PR DESCRIPTION
Deployed to stage, check eg. https://stage.lobid.org/imagesproxy?url=https://en.wikipedia.org/static/favicon/wikipedia.ico
Resolves https://github.com/hbz/lobid-gnd/issues/385
