### PR TITLE
Add publications fro 2024 to Q1/2026

### DIFF
--- a/gatsby/lobid/static/product/metadaten.community.json
+++ b/gatsby/lobid/static/product/metadaten.community.json
@@ -1,10 +1,8 @@
 {
-  "@context": "https://schema.org/",
+  "@context": "https://schema.org",
   "id": "https://lobid.org/product/metadaten.community",
   "url": "https://metadaten.community",
-  "type": [
-    "Product"
-  ],
+  "type": ["Product"],
   "name": {
     "de": "metadaten.community",
     "en": "metadaten.community"

--- a/gatsby/lobid/static/product/oersi.json
+++ b/gatsby/lobid/static/product/oersi.json
@@ -1,17 +1,13 @@
 {
-  "@context": "https://schema.org/",
+  "@context": "https://schema.org",
   "id": "https://lobid.org/product/oersi",
   "url": "https://oersi.org",
-  "type": [
-    "Product"
-  ],
+  "type": ["Product"],
   "name": {
     "de": "OER Search Index",
     "en": "OER Search Index"
   },
-  "alternateName": [
-    "OERSI"
-  ],
+  "alternateName": ["OERSI"],
   "image": "https://oersi.org/resources/logo.svg",
   "startDate": "2020-01-15",
   "description": {

--- a/gatsby/lobid/static/publication/2023-skohub@nfdi4ing-conference.json
+++ b/gatsby/lobid/static/publication/2023-skohub@nfdi4ing-conference.json
@@ -1,43 +1,33 @@
 {
-    "@context": "https://schema.org",
-    "type": [
-        "PresentationDigitalDocument"
-    ],
-    "name": {
-        "en": "SkoHub - Unleash the full potential of controlled vocabularies"
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "name": {
+    "en": "SkoHub - Unleash the full potential of controlled vocabularies"
+  },
+  "description": {
+    "de": "Präsentationsfolien zum Vortrag bei der NDI4Ing Conference 2023, WWW"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/ap#!",
+      "type": "Person",
+      "name": "Adrian Pohl"
     },
-    "description": {
-        "de": "Präsentationsfolien zum Vortrag bei der NDI4Ing Conference 2023, WWW"
-    },
-    "creator": [
-        {
-            "id": "http://lobid.org/team/ap#!",
-            "type": "Person",
-            "name": "Adrian Pohl"
-        },
-        {
-            "id": "http://lobid.org/team/sr#!",
-            "type": "Person",
-            "name": "Steffen Rörtgen"
-        }
-    ],
-    "keywords": [
-        "SKOS",
-        "SkoHub"
-    ],
-    "id": "https://pad.lobid.org/p/skohub@nfdi4ing-conference",
-    "about": [
-        {
-            "id": "https://lobid.org/product/skohub"
-        }
-    ],
-    "datePublished": "2023-09-28",
-    "inLanguage": [
-        "de"
-    ],
-    "audience": [
-        "librarians",
-        "developers"
-    ],
-    "license": "https://creativecommons.org/licenses/by/4.0/"
+    {
+      "id": "http://lobid.org/team/sr#!",
+      "type": "Person",
+      "name": "Steffen Rörtgen"
+    }
+  ],
+  "keywords": ["SKOS", "SkoHub"],
+  "id": "https://pad.lobid.org/p/skohub@nfdi4ing-conference",
+  "about": [
+    {
+      "id": "https://lobid.org/product/skohub"
+    }
+  ],
+  "datePublished": "2023-09-28",
+  "inLanguage": ["en"],
+  "audience": ["librarians", "developers"],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
 }

--- a/gatsby/lobid/static/publication/2024-01-metafacture-workshop@htwk.json
+++ b/gatsby/lobid/static/publication/2024-01-metafacture-workshop@htwk.json
@@ -1,0 +1,55 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "id": "https://slides.lobid.org/2024-01-metafacture-workshop",
+  "name": {
+    "de": "Metadatenworkflows mit Metafacture erstellen und verwalten"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/pc#!",
+      "type": "Person",
+      "name": "Pascal Christoph"
+    },
+    {
+      "id": "http://lobid.org/team/pm#!",
+      "type": "Person",
+      "name": "Petra Maier"
+    },
+    {
+      "id": "http://lobid.org/team/kt#!",
+      "type": "Person",
+      "name": "Katinka Tauber"
+    }
+  ],
+  "description": {
+    "de": "Hands-on Lab im Studiengang Bibliotheks- und Informationswissenschaft an der HTWK Leipzig im Modul \"Metadaten und Metadatenmanagement\""
+  },
+  "about": [
+    {
+      "id": "https://lobid.org/product/metafacture"
+    },
+    {
+      "id": "https://lobid.org/project/metafacture-playground"
+    },
+    {
+      "id": "https://lobid.org/project/metafacture-fix"
+    }
+  ],
+  "keywords": [
+    "metafacture-playground",
+    "metafacture",
+    "metafacture-fix",
+    "metadata",
+    "workshop"
+  ],
+  "datePublished": "2024-01-11",
+  "inLanguage": ["de"],
+  "audience": [
+    "metadata practitioners",
+    "management",
+    "librarians",
+    "developers"
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2024-08-amb.json
+++ b/gatsby/lobid/static/publication/2024-08-amb.json
@@ -1,0 +1,28 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "id": "https://pad.lobid.org/p/2024-08-19-amb",
+  "name": {
+    "de": "AMB – Allgemeines Metadatenprofil für Bildungsressourcen"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/ap#!",
+      "type": "Person",
+      "name": "Adrian Pohl"
+    }
+  ],
+  "description": {
+    "de": "Impulsvortrag zum Austausch über AMB und DIF, 19.8.2024"
+  },
+  "about": [
+    {
+      "id": "https://lobid.org/project/amb"
+    }
+  ],
+  "keywords": ["amb", "oer", "metadata"],
+  "datePublished": "2024-08-19",
+  "inLanguage": ["de"],
+  "audience": ["metadata practitioners"],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2024-10-metafacture-workshop@zbiw.json
+++ b/gatsby/lobid/static/publication/2024-10-metafacture-workshop@zbiw.json
@@ -1,0 +1,55 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "id": "https://pad.lobid.org/p/2024-10-08-Bibliothekarische-Metadatenworkflows-mit-Metafacture-erstellen",
+  "name": {
+    "de": "Bibliothekarische Metadatenworkflows mit Metafacture erstellen"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/pc#!",
+      "type": "Person",
+      "name": "Pascal Christoph"
+    },
+    {
+      "id": "http://lobid.org/team/pm#!",
+      "type": "Person",
+      "name": "Petra Maier"
+    },
+    {
+      "id": "http://lobid.org/team/tb#!",
+      "type": "Person",
+      "name": "Tobias Bülte"
+    }
+  ],
+  "description": {
+    "de": "Workshop beim ZBIW, Köln"
+  },
+  "about": [
+    {
+      "id": "https://lobid.org/product/metafacture"
+    },
+    {
+      "id": "https://lobid.org/project/metafacture-playground"
+    },
+    {
+      "id": "https://lobid.org/project/metafacture-fix"
+    }
+  ],
+  "keywords": [
+    "metafacture-playground",
+    "metafacture",
+    "metafacture-fix",
+    "metadata",
+    "workshop"
+  ],
+  "datePublished": "2024-10-08",
+  "inLanguage": ["de"],
+  "audience": [
+    "metadata practitioners",
+    "management",
+    "librarians",
+    "developers"
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2024-11-oersi.json
+++ b/gatsby/lobid/static/publication/2024-11-oersi.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "name": {
+    "de": "Verbesserte Suche und Auffindbarkeit mit OERSI"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/ap#!",
+      "type": "Person",
+      "name": "Adrian Pohl"
+    }
+  ],
+  "description": {
+    "de": " Lightning Talk bei der Online-Fachtagung \"Maßnahmen zur Nachnutzung und Wiederverwendung von OER im Hochschulbereich\""
+  },
+  "keywords": [
+    "oer",
+    "open educational resources",
+    "resource discovery",
+    "oersi"
+  ],
+  "about": [
+    {
+      "id": "https://lobid.org/product/oersi"
+    }
+  ],
+  "id": "https://pad.lobid.org/p/2024-11-05-oersi",
+  "datePublished": "2024-11-05",
+  "inLanguage": ["de"],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2025-01-metafacture@htwk.json
+++ b/gatsby/lobid/static/publication/2025-01-metafacture@htwk.json
@@ -1,0 +1,49 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "id": "https://pad.lobid.org/p/2025-01-22-Bibliothekarische-Metadatenworkflows-mit-Metafacture-erstellen",
+  "name": {
+    "de": "Bibliothekarische Metadatenworkflows mit Metafacture erstellen und verwalten"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/pc#!",
+      "type": "Person",
+      "name": "Pascal Christoph"
+    },
+    {
+      "id": "http://lobid.org/team/tb#!",
+      "type": "Person",
+      "name": "Tobias Bülte"
+    },
+    {
+      "id": "http://lobid.org/team/pm#!",
+      "type": "Person",
+      "name": "Petra Maier"
+    }
+  ],
+  "description": {
+    "de": "Studiengang Bibliotheks- und Informationswissenschaft an der HTWK Leipzig im Modul \"Metadaten und Metadatenmanagement\""
+  },
+  "about": [
+    {
+      "id": "https://lobid.org/product/metafacture"
+    },
+    {
+      "id": "https://lobid.org/project/metafacture-playground"
+    },
+    {
+      "id": "https://lobid.org/project/metafacture-fix"
+    }
+  ],
+  "keywords": [
+    "metafacture-playground",
+    "metafacture",
+    "metafacture-fix",
+    "metadata"
+  ],
+  "datePublished": "2025-01-22",
+  "inLanguage": ["de"],
+  "audience": ["lis students"],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2025-05-metafacture@kim.json
+++ b/gatsby/lobid/static/publication/2025-05-metafacture@kim.json
@@ -1,0 +1,54 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "id": "https://pad.lobid.org/p/2025-Dini-Kim-Metafacture-Workshop-Folien",
+  "name": {
+    "de": "Metafacture Revisited. Metadaten verarbeiten, transfomieren und bereinigen mit Metafacture Core und Fix"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/pc#!",
+      "type": "Person",
+      "name": "Pascal Christoph"
+    },
+    {
+      "id": "http://lobid.org/team/tb#!",
+      "type": "Person",
+      "name": "Tobias Bülte"
+    },
+    {
+      "id": "http://lobid.org/team/pm#!",
+      "type": "Person",
+      "name": "Petra Maier"
+    }
+  ],
+  "description": {
+    "de": "Hands-on Lab beim KIM-Workshop 2025, Mannheim"
+  },
+  "about": [
+    {
+      "id": "https://lobid.org/product/metafacture"
+    },
+    {
+      "id": "https://lobid.org/project/metafacture-playground"
+    },
+    {
+      "id": "https://lobid.org/project/metafacture-fix"
+    }
+  ],
+  "keywords": [
+    "metafacture-playground",
+    "metafacture",
+    "metafacture-fix",
+    "metadata"
+  ],
+  "datePublished": "2025-05-06",
+  "inLanguage": ["de"],
+  "audience": [
+    "metadata practitioners",
+    "management",
+    "librarians",
+    "developers"
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2025-05-skohub@hmc.json
+++ b/gatsby/lobid/static/publication/2025-05-skohub@hmc.json
@@ -1,0 +1,33 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "name": {
+    "en": "Publish & utilize SKOS vocabularies with SkoHub"
+  },
+  "description": {
+    "de": "Präsentationsfolien zum SkoHub-Workshop bei der Helmholtz Metadata Collaboration Conference 2025 in Köln"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/ap#!",
+      "type": "Person",
+      "name": "Adrian Pohl"
+    },
+    {
+      "id": "http://lobid.org/team/tb#!",
+      "type": "Person",
+      "name": "Tobias Bülte"
+    }
+  ],
+  "keywords": ["SKOS", "SkoHub"],
+  "id": "https://pad.lobid.org/p/skohub@HMCConference2025",
+  "about": [
+    {
+      "id": "https://lobid.org/product/skohub"
+    }
+  ],
+  "datePublished": "2025-05-12",
+  "inLanguage": ["en"],
+  "audience": ["librarians", "developers"],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2025-05-strapi@kim.json
+++ b/gatsby/lobid/static/publication/2025-05-strapi@kim.json
@@ -1,0 +1,33 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "name": {
+    "de": "Katalogisierung als Content Management – Integration eines Headless CMS in eine Linked-Data-Umgebung"
+  },
+  "description": {
+    "de": "Vortrag beim KIM-Workshop 2025, Mannheim"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/ap#!",
+      "type": "Person",
+      "name": "Adrian Pohl"
+    },
+    {
+      "id": "http://lobid.org/team/fs#!",
+      "type": "Person",
+      "name": "Fabian Steeg"
+    }
+  ],
+  "keywords": ["lobid", "JSON-LD", "Linked Open Data", "libraries"],
+  "id": "https://pad.lobid.org/p/20250507-strapi@kim",
+  "about": [
+    {
+      "id": "https://lobid.org/project/rpb/"
+    }
+  ],
+  "datePublished": "2025-05-07",
+  "inLanguage": ["de"],
+  "audience": ["librarians", "developers", "metadata practitioners"],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2025-05-strapi@kim.json
+++ b/gatsby/lobid/static/publication/2025-05-strapi@kim.json
@@ -23,7 +23,7 @@
   "id": "https://pad.lobid.org/p/20250507-strapi@kim",
   "about": [
     {
-      "id": "https://lobid.org/project/rpb/"
+      "id": "https://lobid.org/project/rpb"
     }
   ],
   "datePublished": "2025-05-07",

--- a/gatsby/lobid/static/publication/2025-06-mc@bibliocon.json
+++ b/gatsby/lobid/static/publication/2025-06-mc@bibliocon.json
@@ -1,0 +1,33 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "id": "https://pad.lobid.org/p/mc-bibliocon25",
+  "name": {
+    "de": "metadaten.community – Ein Online-Forum für Metadatenpraktiker:innen"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/ap#!",
+      "type": "Person",
+      "name": "Adrian Pohl"
+    },
+    {
+      "type": "Person",
+      "name": "Tracy Arndt",
+      "id": "http://www.wikidata.org/entity/Q111973630"
+    }
+  ],
+  "description": {
+    "de": "Vortrag beim Bibliothekskongress 2025, Bremen"
+  },
+  "about": [
+    {
+      "id": "https://lobid.org/product/metadaten.community"
+    }
+  ],
+  "keywords": ["metadaten.community", "metadaten", "fachaustausch"],
+  "datePublished": "2025-06-24",
+  "inLanguage": ["de"],
+  "audience": ["metadata practitioners", "librarians"],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2025-11-metafacture@swib.json
+++ b/gatsby/lobid/static/publication/2025-11-metafacture@swib.json
@@ -1,0 +1,44 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "id": "https://pad.lobid.org/p/SWIB2025-metafactureWorkshopSlides",
+  "name": {
+    "de": "Creating LOUD with Metafacture"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/pc#!",
+      "type": "Person",
+      "name": "Pascal Christoph"
+    },
+    {
+      "id": "http://lobid.org/team/tb#!",
+      "type": "Person",
+      "name": "Tobias Bülte"
+    }
+  ],
+  "description": {
+    "de": "Online workshop at SWIB25"
+  },
+  "about": [
+    {
+      "id": "https://lobid.org/product/metafacture"
+    },
+    {
+      "id": "https://lobid.org/project/metafacture-playground"
+    },
+    {
+      "id": "https://lobid.org/project/metafacture-fix"
+    }
+  ],
+  "keywords": [
+    "metafacture-playground",
+    "metafacture",
+    "metafacture-fix",
+    "metadata"
+  ],
+  "datePublished": "2025-11-17",
+  "inLanguage": ["de"],
+  "audience": ["metadata practitioners", "librarians", "developers"],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2026-01-mc@spk.json
+++ b/gatsby/lobid/static/publication/2026-01-mc@spk.json
@@ -1,0 +1,33 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "id": "https://pad.lobid.org/p/mc@stabi-berlin",
+  "name": {
+    "de": "metadaten.community – Ein Online-Forum für Metadatenpraktiker:innen"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/ap#!",
+      "type": "Person",
+      "name": "Adrian Pohl"
+    },
+    {
+      "type": "Person",
+      "name": "Tracy Arndt",
+      "id": "http://www.wikidata.org/entity/Q111973630"
+    }
+  ],
+  "description": {
+    "de": "Vortrag beim Online-Treffen der AG Metadatenmanagement der SPK Berlin"
+  },
+  "about": [
+    {
+      "id": "https://lobid.org/product/metadaten.community"
+    }
+  ],
+  "keywords": ["metadaten.community", "metadaten", "fachaustausch"],
+  "datePublished": "2026-01-08",
+  "inLanguage": ["de"],
+  "audience": ["metadata practitioners", "librarians"],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2026-02-lobid-gnd4archives.json
+++ b/gatsby/lobid/static/publication/2026-02-lobid-gnd4archives.json
@@ -1,0 +1,27 @@
+{
+  "@context": "https://schema.org",
+  "type": ["PresentationDigitalDocument"],
+  "name": {
+    "de": "lobid-gnd & Reconciliation für Archive"
+  },
+  "creator": [
+    {
+      "id": "http://lobid.org/team/ap#!",
+      "type": "Person",
+      "name": "Adrian Pohl"
+    }
+  ],
+  "description": {
+    "de": "Kurzvortrag beim Treffen der LVR-AFZ"
+  },
+  "keywords": ["lobid", "gnd", "normdaten", "archive"],
+  "about": [
+    {
+      "id": "https://lobid.org/product/lobid"
+    }
+  ],
+  "id": "https://pad.lobid.org/p/20260204-gnd-und-archive",
+  "datePublished": "2026-02-04",
+  "inLanguage": ["de"],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/gatsby/lobid/static/publication/2026-02-lobid-gnd4archives.json
+++ b/gatsby/lobid/static/publication/2026-02-lobid-gnd4archives.json
@@ -17,7 +17,7 @@
   "keywords": ["lobid", "gnd", "normdaten", "archive"],
   "about": [
     {
-      "id": "https://lobid.org/product/lobid"
+      "id": "https://lobid.org/product/lobid-gnd"
     }
   ],
   "id": "https://pad.lobid.org/p/20260204-gnd-und-archive",


### PR DESCRIPTION
Context for this PR: We have links to https://www.hbz-nrw.de/produkte/linked-open-data in different places which are currently redirected to https://www.hbz-nrw.de/de/lobid-resources/. I would like to point the redirect to https://lobid.org/team instead.